### PR TITLE
Add scipy to deptry ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ source = "vcs"
 pythonpath = ["src"]
 testpaths = ["tests"]
 
+[tool.deptry.per_rule_ignores]
+DEP002 = ["scipy"]  # ignore defined dependency thats not used
+
 [tool.mypy]
 ignore_missing_imports = true
 


### PR DESCRIPTION
scipy is necessary for networkx plotting, but not required otherwise.