### PR TITLE
Add argument to pass data directory to pytest CLI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Global pytest fixtures, arguments, and options."""
 
+from pathlib import Path
 from typing import Generator
 
 import pytest
@@ -22,6 +23,12 @@ def pytest_addoption(parser: pytest.Parser):
         default=None,
         help="Optional JSON/dict string of Image overrides for Styx runner.",
     )
+    parser.addoption(
+        "--data-dir",
+        action="store",
+        default=None,
+        help="Directory where test data is located.",
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -36,6 +43,15 @@ def runner(
         data_dir=tmp_dir,
     )
     yield get_global_runner()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def data_dir(request: pytest.FixtureRequest) -> Generator[Path, None, None]:
+    """Yield data directory from pytest command-line."""
+    data_dir = Path(request.config.getoption("--data-dir")).resolve()
+    if not data_dir.exists():
+        raise FileNotFoundError(f"{data_dir} does not exist")
+    yield data_dir
 
 
 @pytest.fixture

--- a/tests/transforms/test_surface.py
+++ b/tests/transforms/test_surface.py
@@ -9,7 +9,7 @@ from neuromaps_prime.transforms.utils import get_vertex_count
 
 
 @pytest.mark.usefixtures("require_workbench")
-def test_surface_sphere_project_unproject(tmp_path: Path) -> None:
+def test_surface_sphere_project_unproject(data_dir: Path, tmp_path: Path) -> None:
     """Test surface_sphere_project_unproject wrapper function.
 
     == Example ==
@@ -22,30 +22,28 @@ def test_surface_sphere_project_unproject(tmp_path: Path) -> None:
     out_sphere              = Path(f"{data_dir}/out_sphere.surf.gii").resolve()
     ------------------------
     """
-    data_dir = Path("/home/bshrestha/projects/Tfunck/neuromaps-nhp-prep/share")
-    sphere_in = Path(
-        data_dir / "Outputs/"
-        "Yerkes19-S1200/"
-        "src-S1200_to-Yerkes19_den-32k_hemi-L_sphere.surf.gii"
+    data_dir = data_dir / "share"
+    sphere_in = (
+        data_dir
+        / "Outputs"
+        / "Yerkes19-S1200"
+        / "src-S1200_to-Yerkes19_den-32k_hemi-L_sphere.surf.gii"
     )
-    sphere_project_to = Path(
-        data_dir / "Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_sphere.surf.gii"
+    sphere_project_to = (
+        data_dir / "Inputs" / "Yerkes19" / "src-Yerkes19_den-32k_hemi-L_sphere.surf.gii"
     )
-    sphere_unproject_from = Path(
-        data_dir / "Outputs/"
-        "D99-Yerkes19/"
-        "src-Yerkes19_to-D99_den-32k_hemi-L_sphere.surf.gii"
+    sphere_unproject_from = (
+        data_dir
+        / "Outputs"
+        / "D99-Yerkes19"
+        / "src-Yerkes19_to-D99_den-32k_hemi-L_sphere.surf.gii"
     )
-
-    sphere_out = f"{tmp_path}/out_sphere.surf.gii"
+    sphere_out = tmp_path / "out_sphere.surf.gii"
 
     result = surface_sphere_project_unproject(
         sphere_in=sphere_in,
         sphere_project_to=sphere_project_to,
         sphere_unproject_from=sphere_unproject_from,
-        sphere_out=sphere_out,
+        sphere_out=str(sphere_out),
     )
-
-    vertices_sphere_in = get_vertex_count(sphere_in)
-    vertices_sphere_out = get_vertex_count(result.sphere_out)
-    assert vertices_sphere_in == vertices_sphere_out
+    assert get_vertex_count(sphere_in) == get_vertex_count(result.sphere_out)

--- a/tests/transforms/test_transforms_utils.py
+++ b/tests/transforms/test_transforms_utils.py
@@ -4,59 +4,44 @@ from pathlib import Path
 
 import pytest
 
-from neuromaps_prime.transforms.utils import (
-    estimate_surface_density,
-    get_vertex_count,
-)
-
-DATA_DIR = Path("/home/bshrestha/projects/Tfunck/neuromaps-nhp-prep/share")
+from neuromaps_prime.transforms.utils import estimate_surface_density, get_vertex_count
 
 
 @pytest.mark.parametrize(
-    "surface_file,expected_density",
+    "surface_fpath,expected_density",
     [
+        ("Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_sphere.surf.gii", "32k"),
+        ("Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_sphere.surf.gii", "10k"),
         (
-            DATA_DIR / "Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_sphere.surf.gii",
-            "32k",
-        ),
-        (
-            DATA_DIR / "Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_sphere.surf.gii",
-            "10k",
-        ),
-        (
-            DATA_DIR / "Outputs/D99-Yerkes19/"
-            "src-Yerkes19_to-D99_den-32k_hemi-L_sphere.surf.gii",
+            "Outputs/D99-Yerkes19/src-Yerkes19_to-D99_den-32k_hemi-L_sphere.surf.gii",
             "32k",
         ),
     ],
 )
-def test_estimate_surface_density(surface_file: Path, expected_density: str) -> None:
+def test_estimate_surface_density(
+    data_dir: Path, surface_fpath: str, expected_density: str
+) -> None:
     """Test estimate_surface_density function with various mesh densities."""
-    result = estimate_surface_density(surface_file)
+    result = estimate_surface_density(data_dir / surface_fpath)
     assert isinstance(result, str)
     assert result == expected_density, f"Expected {expected_density}, but got {result}"
 
 
 @pytest.mark.parametrize(
-    "surface_file,expected_count",
+    "surface_fpath,expected_count",
     [
+        ("Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_sphere.surf.gii", 32492),
+        ("Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_sphere.surf.gii", 10242),
         (
-            DATA_DIR / "Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_sphere.surf.gii",
-            32492,
-        ),
-        (
-            DATA_DIR / "Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_sphere.surf.gii",
-            10242,
-        ),
-        (
-            DATA_DIR / "Outputs/D99-Yerkes19/"
-            "src-Yerkes19_to-D99_den-32k_hemi-L_sphere.surf.gii",
+            "Outputs/D99-Yerkes19/src-Yerkes19_to-D99_den-32k_hemi-L_sphere.surf.gii",
             32492,
         ),
     ],
 )
-def test_get_vertex_count(surface_file: Path, expected_count: int) -> None:
+def test_get_vertex_count(
+    data_dir: Path, surface_fpath: str, expected_count: int
+) -> None:
     """Test get_vertex_count function returns correct vertex count."""
-    result = get_vertex_count(surface_file)
+    result = get_vertex_count(data_dir / surface_fpath)
     assert isinstance(result, int)
     assert result == expected_count, f"Expected {expected_count}, but got {result}"

--- a/tests/transforms/test_volume.py
+++ b/tests/transforms/test_volume.py
@@ -26,25 +26,25 @@ class TestVolumetricTransform:
     """Unit tests for volumetric transformations using `_vol_to_vol`."""
 
     @pytest.fixture
-    def vol_paths(self) -> dict[str, Path]:
+    def vol_paths(self, data_dir: Path) -> dict[str, Path]:
         """Provide all possible source and target paths for tests."""
         return {
-            "t1w_source": Path(
-                "/Users/tamsin.rogers/Desktop/github/neuromaps/"
-                "share_with_T1w/Inputs/D99/src-D99_res-0p25mm_T1w.nii"
-            ),
-            "label_source": Path(
-                "/Users/tamsin.rogers/Desktop/github/neuromaps/"
-                "share_with_T1w/atlas/D99_atlas_v2.0.nii"
-            ),
-            "target_same": Path(
-                "/Users/tamsin.rogers/Desktop/github/neuromaps/"
-                "share_with_T1w/Inputs/NMT2Sym/src-NMT2Sym_res-0p25mm_T1w.nii"
-            ),
-            "target_diff": Path(
-                "/Users/tamsin.rogers/Desktop/github/neuromaps/"
-                "share_with_T1w/Inputs/MEBRAINS/src-MEBRAINS_res-0p40mm_T1w.nii"
-            ),
+            "t1w_source": data_dir
+            / "share"
+            / "Inputs"
+            / "D99"
+            / "src-D99_res-0p25mm_T1w.nii",
+            "label_source": data_dir / "resources" / "D99" / "D99_atlas_v2.0.nii.gz",
+            "target_same": data_dir
+            / "share"
+            / "Inputs"
+            / "NMT2Sym"
+            / "src-NMT2Sym_res-0p25mm_T1w.nii",
+            "target_diff": data_dir
+            / "share"
+            / "Inputs"
+            / "MEBRAINS"
+            / "src-MEBRAINS_res-0p40mm_T1w.nii",
         }
 
     def _extract_res(self, nii_file: Path) -> tuple[float, float, float]:


### PR DESCRIPTION
This PR adds an argument `--data-dir` to the `pytest` CLI to allow for a slightly more dynamic file path to be passed to testing for now. This will allow one to use a local clone of the [`neuromaps-nhp-prep` directory ](https://github.com/tfunck/neuromaps-nhp
). To use, call `pytest --data-dir=<neuromaps-nhp-prep_dir> tests/`

Will need to make sure, at least for now, that the data directory file names are up to date and match across systems. Long term, we should just make use of the graph and its attributes once the files are added to the graph and available online.