### PR TITLE
Add `data_dir` argument to graph

### DIFF
--- a/src/neuromaps_prime/datasets/data/neuromaps_graph.yaml
+++ b/src/neuromaps_prime/datasets/data/neuromaps_graph.yaml
@@ -6,14 +6,14 @@ nodes:
     surfaces:
       41k:
         sphere:
-          left: /home/bshrestha/projects/Tfunck/neuromaps-nhp-prep/share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-L_sphere.surf.gii
-          right: /home/bshrestha/projects/Tfunck/neuromaps-nhp-prep/share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-R_sphere.surf.gii
+          left: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-L_sphere.surf.gii
+          right: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-R_sphere.surf.gii
         midthickness:
-          left: /home/bshrestha/projects/Tfunck/neuromaps-nhp-prep/share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-L_midthickness.surf.gii
-          right: /home/bshrestha/projects/Tfunck/neuromaps-nhp-prep/share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-R_midthickness.surf.gii
+          left: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-L_midthickness.surf.gii
+          right: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-R_midthickness.surf.gii
         white:
-          left: /home/bshrestha/projects/Tfunck/neuromaps-nhp-prep/share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-L_white.surf.gii
-          right: /home/bshrestha/projects/Tfunck/neuromaps-nhp-prep/share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-R_white.surf.gii
+          left: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-L_white.surf.gii
+          right: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-R_white.surf.gii
     volumes:
       2mm:
         T1w: /url/to/src-MEBRAINS_vox-2mm_T1w.nii.gz

--- a/src/neuromaps_prime/graph.py
+++ b/src/neuromaps_prime/graph.py
@@ -20,6 +20,7 @@ see examples/example_graph_init.py for usage.
 
 """
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -75,14 +76,18 @@ class Edge:
 class NeuromapsGraph(nx.MultiDiGraph):
     """Multi-directed graph of brain template spaces and their transformations."""
 
-    def __init__(self, yaml_file: Path | None = None) -> None:
+    def __init__(
+        self, yaml_file: Path | None = None, data_dir: Path | None = None
+    ) -> None:
         """Initialize an empty NeuromapsGraph and populate it from a YAML file."""
         super().__init__()
 
-        if yaml_file is None:
-            yaml_file = Path(__file__).parent / "datasets/data/neuromaps_graph.yaml"
-        self.yaml_path = yaml_file
-        self._build_from_yaml(yaml_file)
+        self.data_dir = data_dir or os.getenv("NEUROMAPS_DATA", None)
+        self.yaml_path = (
+            yaml_file
+            or Path(__file__).parent / "datasets" / "data" / "neuromaps_graph.yaml"
+        )
+        self._build_from_yaml(self.yaml_path)
 
     def _build_from_yaml(self, yaml_file: Path) -> None:
         """Read in the YAML file and call _build_from_dict to populate the graph."""
@@ -161,7 +166,9 @@ class NeuromapsGraph(nx.MultiDiGraph):
                         SurfaceAtlas(
                             name=f"{node_name}_{density}_{hemisphere}_{surface_type}",
                             description=description,
-                            file_path=Path(path),
+                            file_path=Path(path)
+                            if self.data_dir is None
+                            else self.data_dir / path,
                             space=node_name,
                             density=density,
                             hemisphere=hemisphere,
@@ -180,7 +187,9 @@ class NeuromapsGraph(nx.MultiDiGraph):
                     VolumeAtlas(
                         name=f"{node_name}_{resolution}_{volume_type}",
                         description=description,
-                        file_path=Path(path),
+                        file_path=Path(path)
+                        if self.data_dir is None
+                        else self.data_dir / path,
                         space=node_name,
                         resolution=resolution,
                         resource_type=volume_type,
@@ -198,7 +207,9 @@ class NeuromapsGraph(nx.MultiDiGraph):
                     VolumeTransform(
                         name=f"{source_name}_to_{target_name}_{resolution}_{volume_type}",
                         description=f"Transform from {source_name} to {target_name}",
-                        file_path=Path(path),
+                        file_path=Path(path)
+                        if self.data_dir is None
+                        else self.data_dir / path,
                         source_space=source_name,
                         target_space=target_name,
                         resolution=resolution,
@@ -223,7 +234,9 @@ class NeuromapsGraph(nx.MultiDiGraph):
                             description=(
                                 f"Transform from {source_name} to {target_name}"
                             ),
-                            file_path=Path(path),
+                            file_path=Path(path)
+                            if self.data_dir is None
+                            else self.data_dir / path,
                             source_space=source_name,
                             target_space=target_name,
                             density=density,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,24 @@
 """Test suite for graph functionalities in neuromaps_nhp."""
 
+from pathlib import Path
+
 import pytest
 
 from neuromaps_prime.graph import NeuromapsGraph
+
+
+@pytest.mark.usefixtures("require_data")
+def test_graph_initialization_with_data_dir(data_dir: Path, tmp_path: Path) -> None:
+    """Test initializing graph with data directory."""
+    graph = NeuromapsGraph(data_dir=data_dir)
+    assert graph is not None
+    assert graph.data_dir == data_dir
+    assert len(graph.nodes) > 0
+    assert len(graph.edges) > 0
+    surf = graph.fetch_surface_atlas(
+        space="CIVETNMT", density="41k", hemisphere="left", resource_type="midthickness"
+    )
+    assert data_dir.resolve() in surf.file_path.resolve().parents
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds an additional argument to **optionally** allow a data directory to be passed when initializing the `Graph` object via the `data_dir` argument. For now, this is just used to point to the directory of where the data is stored. If provided, this serves as the parent-directory to the file paths provided in the yaml / dictionary object. The data directory can also be passed via the environment variable `NEUROMAPS_DATA`, which would be automatically pulled (though passing the argument will overwrite this).

The added test is incomplete, but ensures that the functionality is usable. Further, this doesn't break existing functionality. Future use case can make use of this variable to set the download location.