### PR TITLE
Fix conditional doc build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,10 +20,9 @@ on:
     - main
   workflow_dispatch:
 
-
 jobs:
   build-and-publish-docs:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
Previous doc build runs were being skipped because either (a) tests were failing or (b) the condition for building the docs never triggered. This PR updates the condition to also trigger on a `workflow_dispatch` event.