### PR TITLE
Optimize `transforms.utils` module

### DIFF
--- a/src/neuromaps_prime/transforms/utils.py
+++ b/src/neuromaps_prime/transforms/utils.py
@@ -1,45 +1,50 @@
 """Utility functions for working with GIFTI files and surface projections."""
 
+from functools import lru_cache
 from pathlib import Path
 
 import nibabel as nib
 
 
 def estimate_surface_density(surface_file: Path) -> str:
-    """Estimate density of a gifti surface file based on number of vertices.
+    """Return density string of GIFTI surface based on vertex count.
 
-    Parameters
-    ----------
-    surface_file : Path
-        Path to the input GIFTI surface file.
+    Args:
+    surface_file: Path to the input GIFTI surface file.
 
     Returns:
-    -------
-    str
         Density string (e.g., '32k', '10k').
     """
-    return str(round(get_vertex_count(surface_file) / 1000)) + "k"
+    count = get_vertex_count(surface_file)
+    return f"{round(count / 1000)}k"
 
 
+@lru_cache
 def get_vertex_count(surface_file: Path) -> int:
-    """Get number of vertices in a gifti surface file.
+    """Get number of vertices in a GIFTI surface file.
 
-    Parameters
-    ----------
-    surface_file : Path
-        Path to the input GIFTI surface file.
+    Args:
+        surface_file: Path to the input GIFTI surface file.
 
     Returns:
-    -------
-    int
         Number of vertices in the surface file.
     """
     surface = nib.load(surface_file)
     if not isinstance(surface, nib.GiftiImage):
-        raise TypeError("Input file is not a GIFTI surface file.")
+        raise TypeError(f"Input file is not a GIFTI surface file: {surface_file}.")
     return surface.darrays[0].data.shape[0]
 
 
-def _get_density_key(d: str) -> int:
-    """Key function to sort density strings like '32k' numerically."""
-    return int(d.rstrip("kK")) if d.lower().endswith("k") else int(d)
+def _get_density_key(density: str) -> int:
+    """Sort density strings like '32k' numerically.
+
+    Args:
+        density: String density key.
+
+    Returns:
+        Approximate integer density value.
+    """
+    density = density.strip().lower()
+    if density.endswith("k"):
+        return int(density.rstrip("k")) * 1000
+    return int(density)


### PR DESCRIPTION
Similar to #47, but for the `transform_utils` sub-module - biggest changes are:

1. Make docstrings consistent with other modules
1. Unlikely, but handle vertex values that are <1000 vertices
1. Adding caching to the vertex count extraction (realistically, this probably isn't needed nor would it be used much)
1. Updating the tests to split integration (requiring data) and unit testing (mocking method / function calls + data).

Let me know if I've missed anything and also if there are any suggestions / questions!