### PR TITLE
Update `transforms.surface` module and tests

### DIFF
--- a/tests/transforms/test_surface.py
+++ b/tests/transforms/test_surface.py
@@ -1,71 +1,292 @@
-"""Tests for surface transformations using Neuromaps NHP."""
+"""Tests for surface transformations."""
 
 from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
+from niwrap import workbench
 
 from neuromaps_prime.graph import NeuromapsGraph
-from neuromaps_prime.transforms.surface import surface_sphere_project_unproject
-from neuromaps_prime.transforms.utils import estimate_surface_density, get_vertex_count
+from neuromaps_prime.transforms import utils
+from neuromaps_prime.transforms.surface import (
+    label_resample,
+    metric_resample,
+    surface_sphere_project_unproject,
+)
+
+
+def touch_inputs(paths: dict[str, Any], skip: set[str]) -> None:
+    """Touch every Path except the skipped keys."""
+    for key, p in paths.items():
+        if key in skip:
+            continue
+        if isinstance(p, Path):
+            p.touch()
+        elif isinstance(p, dict):  # area_surfs
+            p["current-area"].touch()
+            p["new-area"].touch()
+
+
+def run_patched(
+    func_path: str,
+    side_effect: Callable[..., Any] | None = None,
+    return_value: Any = None,
+):
+    """Context manager to patch a workbench function."""
+    return patch(func_path, side_effect=side_effect, return_value=return_value)
+
+
+class TestSurfaceSphereProjectUnproject:
+    """Unit test of surface sphere project unproject function."""
+
+    @pytest.fixture
+    def mock_paths(self, tmp_path: Path) -> dict[str, Any]:
+        """Mock file paths."""
+        return {
+            "sphere_in": tmp_path / "sphere_in.surf.gii",
+            "sphere_project_to": tmp_path / "sphere_project_to.surf.gii",
+            "sphere_unproject_from": tmp_path / "sphere_unproject_from.surf.gii",
+            "sphere_out": str(tmp_path / "out.surf.gii"),
+        }
+
+    @pytest.mark.parametrize(
+        "missing, msg",
+        [
+            ("sphere_in", "Input sphere"),
+            ("sphere_project_to", "project to"),
+            ("sphere_unproject_from", "unproject from"),
+        ],
+    )
+    def test_missing_inputs(self, mock_paths: dict[str, Any], missing: str, msg: str):
+        """Each missing input should raise FileNotFoundError with correct message."""
+        touch_inputs(mock_paths, skip={missing, "sphere_out"})
+        with pytest.raises(FileNotFoundError, match=msg):
+            surface_sphere_project_unproject(**mock_paths)
+
+    def test_success(self, mock_paths: dict[str, Any]):
+        """Test successful call."""
+        touch_inputs(mock_paths, skip={"sphere_out"})
+        mock_result = MagicMock()
+        mock_result.sphere_out = Path(mock_paths["sphere_out"])
+
+        def produce(*args, **kwargs) -> MagicMock:
+            Path(mock_paths["sphere_out"]).touch()
+            return mock_result
+
+        func_path = (
+            "neuromaps_prime.transforms.surface."
+            "workbench.surface_sphere_project_unproject"
+        )
+        with run_patched(func_path, side_effect=lambda **_: produce()) as mock_wb:
+            result = surface_sphere_project_unproject(**mock_paths)
+            mock_wb.assert_called_once_with(**mock_paths)
+            assert result.sphere_out.exists()
+
+    def test_missing_output(self, mock_paths: dict[str, Any]):
+        """Test FileNotFoundError raised if output file is missing."""
+        touch_inputs(mock_paths, skip={"sphere_out"})
+
+        mock_result = MagicMock()
+        mock_result.sphere_out = Path(mock_paths["sphere_out"])
+
+        func_path = (
+            "neuromaps_prime.transforms.surface."
+            "workbench.surface_sphere_project_unproject"
+        )
+        with run_patched(func_path, return_value=mock_result):
+            with pytest.raises(FileNotFoundError, match="Sphere out not found"):
+                surface_sphere_project_unproject(**mock_paths)
+
+
+class TestMetricResample:
+    """Unit test of metric resample."""
+
+    @pytest.fixture
+    def mock_paths(self, tmp_path: Path) -> dict[str, Any]:
+        """Mock file paths."""
+        return {
+            "input_file_path": tmp_path / "metric.shape.gii",
+            "current_sphere": tmp_path / "current_sphere.surf.gii",
+            "new_sphere": tmp_path / "new_sphere.surf.gii",
+            "output_file_path": str(tmp_path / "out.shape.gii"),
+            "area_surfs": workbench.metric_resample_area_surfs(
+                current_area=tmp_path / "current_midthickness.surf.gii",
+                new_area=tmp_path / "new_midthickness.surf.gii",
+            ),
+        }
+
+    @pytest.mark.parametrize(
+        "missing, msg",
+        [
+            ("input_file_path", "Input file"),
+            ("current_sphere", "Current sphere"),
+            ("new_sphere", "New sphere"),
+        ],
+    )
+    def test_missing_inputs(self, mock_paths: dict[str, Any], missing: str, msg: str):
+        """Each missing input should raise FileNotFoundError with correct message."""
+        touch_inputs(mock_paths, skip={missing, "output_file_path", "area_surfs"})
+        with pytest.raises(FileNotFoundError, match=msg):
+            metric_resample(**mock_paths, method="ADAP_BARY_AREA")
+
+    def test_invalid_resample_method(self, mock_paths: dict[str, Any]):
+        """Test NotImplementedError raised if invalid resample method passed."""
+        touch_inputs(mock_paths, skip={"output_file_path", "area_surfs"})
+        with pytest.raises(NotImplementedError, match="not implemented"):
+            metric_resample(**mock_paths, method="invalid")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("method", ["ADAP_BARY_AREA", "BARYCENTRIC"])
+    def test_success(self, mock_paths: dict[str, Any], method: str):
+        """Test successful call."""
+        touch_inputs(mock_paths, skip={"output_file_path"})
+
+        mock_result = MagicMock()
+        mock_result.metric_out = Path(mock_paths["output_file_path"])
+
+        def produce(*args, **kwargs) -> MagicMock:
+            Path(mock_paths["output_file_path"]).touch()
+            return mock_result
+
+        func_path = "neuromaps_prime.transforms.surface.workbench.metric_resample"
+        with run_patched(func_path, side_effect=lambda **_: produce()) as mock_wb:
+            metric_resample(**mock_paths, method=method)  # type: ignore[arg-type]
+            mock_wb.assert_called_once()
+            assert Path(mock_paths["output_file_path"]).exists()
+
+    def test_missing_output(self, mock_paths: dict[str, Any]):
+        """Test FileNotFoundError raised if output file is missing."""
+        touch_inputs(mock_paths, skip={"output_file_path"})
+
+        mock_result = MagicMock()
+        mock_result.metric_out = Path(mock_paths["output_file_path"])
+
+        func_path = "neuromaps_prime.transforms.surface.workbench.metric_resample"
+        with run_patched(func_path, return_value=mock_result):
+            with pytest.raises(FileNotFoundError, match="Metric out not found"):
+                metric_resample(**mock_paths, method="ADAP_BARY_AREA")
+
+
+class TestLabelResample:
+    """Unit test of label resample."""
+
+    @pytest.fixture
+    def mock_paths(self, tmp_path: Path) -> dict[str, Any]:
+        """Mock file paths."""
+        return {
+            "input_file_path": tmp_path / "metric.label.gii",
+            "current_sphere": tmp_path / "current_sphere.surf.gii",
+            "new_sphere": tmp_path / "new_sphere.surf.gii",
+            "output_file_path": str(tmp_path / "out.label.gii"),
+            "area_surfs": workbench.label_resample_area_surfs(
+                current_area=tmp_path / "current_midthickness.surf.gii",
+                new_area=tmp_path / "new_midthickness.surf.gii",
+            ),
+        }
+
+    @pytest.mark.parametrize(
+        "missing, msg",
+        [
+            ("input_file_path", "Input file"),
+            ("current_sphere", "Current sphere"),
+            ("new_sphere", "New sphere"),
+        ],
+    )
+    def test_missing_inputs(self, mock_paths: dict[str, Any], missing: str, msg: str):
+        """Each missing input should raise FileNotFoundError with correct message."""
+        touch_inputs(mock_paths, skip={missing, "output_file_path", "area_surfs"})
+        with pytest.raises(FileNotFoundError, match=msg):
+            label_resample(**mock_paths, method="ADAP_BARY_AREA")
+
+    def test_invalid_resample_method(self, mock_paths: dict[str, Any]):
+        """Test NotImplementedError raised if invalid resample method passed."""
+        touch_inputs(mock_paths, skip={"output_file_path", "area_surfs"})
+        with pytest.raises(NotImplementedError, match="not implemented"):
+            label_resample(**mock_paths, method="invalid")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("method", ["ADAP_BARY_AREA", "BARYCENTRIC"])
+    def test_success(self, mock_paths: dict[str, Any], method: str):
+        """Test successful call."""
+        touch_inputs(mock_paths, skip={"output_file_path"})
+
+        mock_result = MagicMock()
+        mock_result.label_out = Path(mock_paths["output_file_path"])
+
+        def produce(*args, **kwargs) -> MagicMock:
+            Path(mock_paths["output_file_path"]).touch()
+            return mock_result
+
+        func_path = "neuromaps_prime.transforms.surface.workbench.label_resample"
+        with run_patched(func_path, side_effect=lambda **_: produce()) as mock_wb:
+            label_resample(**mock_paths, method=method)  # type: ignore[arg-type]
+            mock_wb.assert_called_once()
+            assert Path(mock_paths["output_file_path"]).exists()
+
+    def test_missing_output(self, mock_paths: dict[str, Any]):
+        """Test FileNotFoundError raised if output file is missing."""
+        touch_inputs(mock_paths, skip={"output_file_path"})
+
+        mock_result = MagicMock()
+        mock_result.label_out = Path(mock_paths["output_file_path"])
+
+        func_path = "neuromaps_prime.transforms.surface.workbench.label_resample"
+        with run_patched(func_path, return_value=mock_result):
+            with pytest.raises(FileNotFoundError, match="Label out not found"):
+                label_resample(**mock_paths, method="ADAP_BARY_AREA")
 
 
 @pytest.mark.usefixtures("require_workbench")
-@pytest.mark.usefixtures("require_data")
-def test_surface_sphere_project_unproject(data_dir: Path, tmp_path: Path) -> None:
-    """Test surface_sphere_project_unproject wrapper function.
+class TestSurfaceTransformIntegration:
+    """Integration tests calling Workbench and using real data."""
 
-    == Example ==
-    ------------------------
-    S1200 to Yerkes19 to D99
-    ------------------------
-    sphere_in               = S1200_aligned_to_Yerkes19 (Input)
-    project_to_sphere       = Yerkes19 (Intermediate)
-    unproject_from_sphere   = Yerkes19_to_D99 (Target)
-    out_sphere              = Path(f"{data_dir}/out_sphere.surf.gii").resolve()
-    ------------------------
-    """
-    graph = NeuromapsGraph(data_dir=data_dir)
-    sphere_in_transform = graph.fetch_surface_to_surface_transform(
-        source="S1200",
-        target="Yerkes19",
-        density="32k",
-        hemisphere="left",
-        resource_type="sphere",
-    )
-    assert sphere_in_transform is not None
-    sphere_in = sphere_in_transform.fetch()
+    def test_surface_sphere_project_unproject(
+        self, tmp_path: Path, graph: NeuromapsGraph
+    ) -> None:
+        """Integration test of surface_sphere_project_unproject."""
+        sphere_in = graph.fetch_surface_to_surface_transform(
+            source="S1200",
+            target="Yerkes19",
+            density="32k",
+            hemisphere="left",
+            resource_type="sphere",
+        )
+        sphere_in = sphere_in
+        sphere_project_to = graph.fetch_surface_atlas(
+            space="Yerkes19",
+            density="32k",
+            hemisphere="left",
+            resource_type="sphere",
+        )
+        sphere_unproject_from = graph.fetch_surface_to_surface_transform(
+            source="Yerkes19",
+            target="D99",
+            density="32k",
+            hemisphere="left",
+            resource_type="sphere",
+        )
+        sphere_out = tmp_path / "out_sphere.surf.gii"
+        assert sphere_in is not None
+        assert sphere_project_to is not None
+        assert sphere_unproject_from is not None
+        result = surface_sphere_project_unproject(
+            sphere_in=sphere_in.fetch(),
+            sphere_project_to=sphere_project_to.fetch(),
+            sphere_unproject_from=sphere_unproject_from.fetch(),
+            sphere_out=str(sphere_out),
+        )
+        assert utils.get_vertex_count(sphere_in) == utils.get_vertex_count(  # type: ignore[arg-type]
+            result.sphere_out
+        )
 
-    sphere_project_to_transform = graph.fetch_surface_atlas(
-        space="Yerkes19",
-        density="32k",
-        hemisphere="left",
-        resource_type="sphere",
-    )
-    assert sphere_project_to_transform is not None
-    sphere_project_to = sphere_project_to_transform.fetch()
+    @pytest.mark.skip(reason="No metric data to test resampling")
+    def test_metric_resample(self, tmp_path: Path, graph: NeuromapsGraph) -> None:
+        """Integration test of metric_resample."""
+        pass
 
-    sphere_unproject_from_transform = graph.fetch_surface_to_surface_transform(
-        source="Yerkes19",
-        target="D99",
-        density="32k",
-        hemisphere="left",
-        resource_type="sphere",
-    )
-    assert sphere_unproject_from_transform is not None
-    sphere_unproject_from = sphere_unproject_from_transform.fetch()
-
-    sphere_out = tmp_path / "out_sphere.surf.gii"
-
-    result = surface_sphere_project_unproject(
-        sphere_in=sphere_in,
-        sphere_project_to=sphere_project_to,
-        sphere_unproject_from=sphere_unproject_from,
-        sphere_out=str(sphere_out),
-    )
-
-    vertices_sphere_in = get_vertex_count(sphere_in)
-    vertices_sphere_out = get_vertex_count(result.sphere_out)
-    assert vertices_sphere_in == vertices_sphere_out
+    @pytest.mark.skip(reason="No label data to test resampling")
+    def test_label_resample(self, tmp_path: Path, graph: NeuromapsGraph) -> None:
+        """Integration test of label_resample."""
+        pass
 
 
 @pytest.mark.usefixtures("require_workbench")
@@ -83,12 +304,12 @@ def test_surface_to_surface(tmp_path: Path, data_dir: Path) -> None:
         source=source_space,
         target=target_space,
         density=density,
-        hemisphere=hemisphere,
+        hemisphere=hemisphere,  # type: ignore[arg-type]
         output_file_path=str(tmp_path / "output.surf.gii"),
     )
 
     assert transform is not None
-    assert estimate_surface_density(transform.fetch()) == density
+    assert utils.estimate_surface_density(transform.fetch()) == density
 
 
 @pytest.mark.parametrize(
@@ -126,13 +347,13 @@ def test_surface_to_surface_transformer(
         input_file=data_dir / input_file,
         source_space=source_space,
         target_space=target_space,
-        hemisphere=hemisphere,
+        hemisphere=hemisphere,  # type: ignore[arg-type]
         output_file_path=output_file_path,
     )
 
     assert output is not None
     target_density = graph.find_highest_density(space=target_space)
     if transformer_type == "metric":
-        assert estimate_surface_density(output.metric_out) == target_density
+        assert utils.estimate_surface_density(output.metric_out) == target_density  # type: ignore[arg-type]
     elif transformer_type == "label":
-        assert estimate_surface_density(output.label_out) == target_density
+        assert utils.estimate_surface_density(output.label_out) == target_density  # type: ignore[arg-type]


### PR DESCRIPTION
Another PR updating the existing code base:

1. Make docstrings consistent with other modules
2. Aggregate the check for file existence
3. Accept `string` or ` Path` as inputs to the surface, and then converting to `Path` within the function
4. Updating the tests to split integration (requiring data) and unit testing (mocking method / function calls + data)
  a. Skipped testing the resampling methods in the integration due to lack of data in the existing Graph

I've kept the tests associated with the Graph method here for now. I think we will want to move these out of this testing module and into the graph testing module, but will make that change in a future PR. Left it in here for now. 