### PR TITLE
Simplify `graph.add_transforms`

### DIFF
--- a/src/neuromaps_prime/graph.py
+++ b/src/neuromaps_prime/graph.py
@@ -410,12 +410,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
             weight=float(hop_idx),
         )
         if add_edge:
-            self.add_transform(
-                source_space=source,
-                target_space=next_space,
-                key=self.surface_to_surface_key,
-                transform=new_transform,
-            )
+            self.add_transform(transform=new_transform, key=self.surface_to_surface_key)
 
         return new_transform
 
@@ -669,10 +664,8 @@ class NeuromapsGraph(nx.MultiDiGraph):
 
     def add_transform(
         self,
-        source_space: str,
-        target_space: str,
-        key: str,
         transform: SurfaceTransform | VolumeTransform,
+        key: str,
     ) -> None:
         """Add a transform as an edge in the graph."""
         match transform:
@@ -683,8 +676,8 @@ class NeuromapsGraph(nx.MultiDiGraph):
                 )
                 self._surface_transform_cache[
                     (
-                        source_space,
-                        target_space,
+                        transform.source_space,
+                        transform.target_space,
                         transform.density,
                         transform.hemisphere.lower(),
                         transform.resource_type,
@@ -697,17 +690,20 @@ class NeuromapsGraph(nx.MultiDiGraph):
                 )
                 self._volume_transform_cache[
                     (
-                        source_space,
-                        target_space,
+                        transform.source_space,
+                        transform.target_space,
                         transform.resolution,
                         transform.resource_type,
                     )
                 ] = transform
             case _:
                 raise TypeError(f"Unsupported transform type: {type(transform)}")
-
         self.add_edge(
-            source_space, target_space, key=key, data=edge, weight=transform.weight
+            transform.source_space,
+            transform.target_space,
+            key=key,
+            data=edge,
+            weight=transform.weight,
         )
 
     def search_surface_atlases(

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -100,7 +100,7 @@ nodes:
             file_path=test_surf,
             description="Test surface transform",
         )
-        graph.add_transform(source, target, graph.surface_to_surface_key, sf)
+        graph.add_transform(sf, graph.surface_to_surface_key)
         fetched = graph.fetch_surface_to_surface_transform(
             source, target, "32k", "left", "midthickness"
         )
@@ -131,14 +131,14 @@ nodes:
             file_path=test_vol,
             description="Test volume transform",
         )
-        graph.add_transform(source, target, graph.volume_to_volume_key, vf)
+        graph.add_transform(vf, graph.volume_to_volume_key)
         fetched = graph.fetch_volume_to_volume_transform(source, target, "1mm", "T1w")
         assert fetched is vf
 
     def test_add_invalid_trasnform(self, graph: NeuromapsGraph) -> None:
         """Test adding invalid transform type raises error."""
         with pytest.raises(TypeError, match="Unsupported transform type"):
-            graph.add_transform("source", "target", key="key", transform="invalid")  # type: ignore[arg-type]
+            graph.add_transform("invalid", key="key")  # type: ignore[arg-type]
 
     def test_fetch_volume_atlas(self, graph: NeuromapsGraph) -> None:
         """Test fetching volume atlas."""

--- a/tests/graph/test_surf_to_surf.py
+++ b/tests/graph/test_surf_to_surf.py
@@ -282,10 +282,9 @@ class TestSurfaceToSurfaceTransformPrivate:
         mock_graph._get_hop_output_file.assert_called_once()
         mock_graph._two_hops.assert_called_once()
         mock_graph.add_transform.assert_called_once()
-        add_xfm_call = mock_graph.add_transform.call_args[1]
-        assert add_xfm_call["source_space"] == "A"
-        assert add_xfm_call["target_space"] == "C"
         assert isinstance(result, models.SurfaceTransform)
+        assert result.source_space == "A"
+        assert result.target_space == "C"
         assert result.file_path == composed_path
         assert result.weight == 2.0
 


### PR DESCRIPTION
`source_space` and `target_space` is already included as part of the transform dataclass and doesn't need to be separately passed in.