### PR TITLE
Add surface-to-volume method

### DIFF
--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -595,7 +595,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         Returns:
             Path to the surface resampled to volume.
         """
-        return self.surface_ops.transform_surface_to_volume(
+        return self.surface_ops.transform_surface_to_volume(  # pragma: no cover
             transformer_type=transformer_type,
             input_file=input_file,
             ref_volume=ref_volume,

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -556,6 +556,60 @@ class NeuromapsGraph(nx.MultiDiGraph):
             provider=provider,
         )
 
+    def surface_to_volume_transformer(
+        self,
+        transformer_type: Literal["metric", "label"],
+        input_file: Path,
+        ref_volume: Path,
+        source_space: str,
+        target_space: str,
+        hemisphere: Literal["left", "right"],
+        output_file_path: str,
+        source_density: str | None = None,
+        target_density: str | None = None,
+        area_resource: str = "midthickness",
+        *,
+        add_edge: bool = True,
+        provider: str | None = None,
+    ) -> Path | None:
+        """Project a volume to surface then resample to target_space.
+
+        Args:
+            transformer_type: ``'metric'`` or ``'label'``.
+            input_file: NIfTI volume in source_space.
+            ref_volume: Reference volume space to transform to.
+            source_space: Source brain template space.
+            target_space: Target brain template space.
+            hemisphere: ``'left'`` or ``'right'``.
+            output_file_path: Path for the final resampled GIFTI output.
+            source_density: Source surface density. Highest available used
+                when ``None``.
+            target_density: Target surface density. Highest available used
+                when ``None``.
+            area_resource: Surface type for area correction
+                (default ``'midthickness'``).
+            add_edge: Whether to register composed transforms.
+            provider: Optional provider name. Falls back to the first
+                registered provider when ``None``.
+
+        Returns:
+            Path to the surface resampled to volume.
+        """
+        return self.surface_ops.transform_surface_to_volume(
+            transformer_type=transformer_type,
+            input_file=input_file,
+            ref_volume=ref_volume,
+            source_space=source_space,
+            target_space=target_space,
+            hemisphere=hemisphere,
+            output_file_path=output_file_path,
+            source_density=source_density,
+            target_density=target_density,
+            area_resource=area_resource,
+            add_edge=add_edge,
+            provider=provider,
+        )
+
     def volume_to_volume_transformer(
         self,
         input_file: Path,

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -139,7 +139,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
             TypeError: If atlas is not SurfaceAtlas or VolumeAtlas.
             ValueError: If atlas space is not present in the graph.
         """
-        if not isinstance(atlas, (SurfaceAtlas, VolumeAtlas)):
+        if not isinstance(atlas, (SurfaceAtlas | VolumeAtlas)):
             raise TypeError(f"Unsupported atlas type: {type(atlas)}")
 
         node_name = atlas.space
@@ -542,7 +542,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
             Path to the resampled output, or ``None`` if the transform could
             not be resolved.
         """
-        return self.surface_ops.transform(
+        return self.surface_ops.transform_surface(
             transformer_type=transformer_type,
             input_file=input_file,
             source_space=source_space,

--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 from typing import Any, Literal
 
+from niwrap import workbench
 from pydantic import BaseModel, PrivateAttr
 
 from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'd)
@@ -176,6 +177,102 @@ class SurfaceTransformOps(BaseModel):
                     area_surfs={"current-area": current_area, "new-area": new_area},
                     output_file_path=output_file_path,
                 ).metric_out
+
+    def transform_surface_to_volume(
+        self,
+        transformer_type: Literal["metric", "label"],
+        input_file: Path,
+        ref_volume: Path,
+        source_space: str,
+        target_space: str,
+        hemisphere: Literal["left", "right"],
+        output_file_path: str,
+        source_density: str | None = None,
+        target_density: str | None = None,
+        area_resource: str = "midthickness",
+        *,
+        add_edge: bool = True,
+        provider: str | None = None,
+    ) -> Path:
+        """Resample from source to target on surface and transform to volume.
+
+        Two-stage pipeline:
+          1. Surface → surface resampling via :class:`SurfaceTransformOps`.
+          2. Transform surface → volume
+
+        Args:
+            transformer_type: ``'metric'`` or ``'label'``.
+            input_file: Input GIFTI file to resample.
+            ref_volume: Reference volume space to transform to.
+            source_space: Source brain template space.
+            target_space: Target brain template space.
+            hemisphere: ``'left'`` or ``'right'``.
+            output_file_path: Path for the resampled output file.
+            source_density: Source mesh density. Estimated from input_file
+                when ``None``.
+            target_density: Target mesh density. Highest available used when
+                ``None``.
+            area_resource: Surface type used for area correction
+                (default ``'midthickness'``).
+            add_edge: Whether to cache and register composed multi-hop
+                transforms as new graph edges.
+            provider: Optional provider name. Falls back to the first
+                registered provider when ``None``.
+
+        Returns:
+            Path to the resampled output NIFTI, or ``None`` if the surface
+            transform could not be resolved.
+
+        Raises:
+            ValueError: If transformer_type is invalid, or required surface
+                resources are missing.
+            FileNotFoundError: If input_file does not exist.
+        """
+        out_surface_fname = (
+            "out.label.gii" if transformer_type == "label" else "out.shape.gii"
+        )
+        out_surface = self.transform_surface(
+            transformer_type=transformer_type,
+            input_file=input_file,
+            source_space=source_space,
+            target_space=target_space,
+            hemisphere=hemisphere,
+            output_file_path=out_surface_fname,
+            source_density=source_density,
+            target_density=target_density,
+            area_resource=area_resource,
+            add_edge=add_edge,
+            provider=provider,
+        )
+        if out_surface is None:
+            raise FileNotFoundError("Unable to perform transformation to target space.")
+
+        target_density = target_density or self.utils.find_highest_density(
+            space=target_space
+        )
+        target_surface = self.cache.get_surface_atlas(
+            space=target_space,
+            density=target_density,
+            hemisphere=hemisphere,
+            resource_type="midthickness",
+        )
+        if target_surface is None:
+            raise FileNotFoundError("Unable to find target surface.")
+        match transformer_type:
+            case "label":
+                return workbench.label_to_volume_mapping(
+                    label=out_surface,
+                    surface=target_surface.file_path,
+                    volume_space=ref_volume,
+                    volume_out=output_file_path,
+                ).volume_out
+            case "metric":
+                return workbench.metric_to_volume_mapping(
+                    metric=out_surface,
+                    surface=target_surface.file_path,
+                    volume_space=ref_volume,
+                    volume_out=output_file_path,
+                ).volume_out
 
     # ------------------------------------------------------------------ #
     # Sphere transform resolution                                          #

--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -10,7 +10,6 @@ import logging
 from pathlib import Path
 from typing import Any, Literal
 
-from niwrap import get_global_runner
 from pydantic import BaseModel, PrivateAttr
 
 from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'd)
@@ -57,13 +56,13 @@ class SurfaceTransformOps(BaseModel):
 
         Lazily grab logger from Graph initialization.
         """
-        self._logger = logging.getLogger(get_global_runner().logger_name)
+        self._logger = logging.getLogger("neuromaps-PRIME")
 
     # ------------------------------------------------------------------ #
-    # Public transformer                                                   #
+    # Surface-to-surface                                                 #
     # ------------------------------------------------------------------ #
 
-    def transform(  # pragma: no cover (individual pieces tested)
+    def transform_surface(
         self,
         transformer_type: Literal["metric", "label"],
         input_file: Path,
@@ -177,9 +176,6 @@ class SurfaceTransformOps(BaseModel):
                     area_surfs={"current-area": current_area, "new-area": new_area},
                     output_file_path=output_file_path,
                 ).metric_out
-            case _:
-                msg = f"Unknown transformer_type: {transformer_type}"
-                raise ValueError(msg)
 
     # ------------------------------------------------------------------ #
     # Sphere transform resolution                                          #

--- a/src/neuromaps_prime/graph/transforms/volume.py
+++ b/src/neuromaps_prime/graph/transforms/volume.py
@@ -190,7 +190,7 @@ class VolumeTransformOps(BaseModel):
             area_resource=area_resource,
         )
 
-        return self.surface_ops.transform(
+        return self.surface_ops.transform_surface(
             transformer_type=transformer_type,
             input_file=projected,
             source_space=source_space,

--- a/tests/unit/graph/transformers/test_surf_to_surf.py
+++ b/tests/unit/graph/transformers/test_surf_to_surf.py
@@ -74,7 +74,7 @@ class TestSurfaceToSurfaceTransformer:
     ) -> None:
         """Test successful metric/label transformation delegates to surface ops."""
         mock_output = Path(basic_params.output_file_path)
-        mock_transformer.surface_ops.transform.return_value = mock_output
+        mock_transformer.surface_ops.transform_surface.return_value = mock_output
 
         with patch(
             "neuromaps_prime.transforms.utils.estimate_surface_density",
@@ -83,7 +83,7 @@ class TestSurfaceToSurfaceTransformer:
             result = mock_transformer.surface_to_surface_transformer(
                 transformer_type=transformer_type, **basic_params._asdict()
             )
-        mock_transformer.surface_ops.transform.assert_called_once_with(
+        mock_transformer.surface_ops.transform_surface.assert_called_once_with(
             transformer_type=transformer_type,
             **basic_params._asdict(),
             area_resource="midthickness",
@@ -106,7 +106,7 @@ class TestSurfaceToSurfaceTransformer:
         self, mock_transformer: NeuromapsGraph, basic_params: BasicParams
     ) -> None:
         """Test None returned if transform not found."""
-        mock_transformer.surface_ops.transform.return_value = None
+        mock_transformer.surface_ops.transform_surface.return_value = None
 
         with patch(
             "neuromaps_prime.transforms.utils.estimate_surface_density",
@@ -122,7 +122,7 @@ class TestSurfaceToSurfaceTransformer:
     ) -> None:
         """Test that ValueError is raised when a required surface atlas is missing."""
         mock_transformer.surface_ops = MagicMock()
-        mock_transformer.surface_ops.transform.side_effect = ValueError(
+        mock_transformer.surface_ops.transform_surface.side_effect = ValueError(
             "No 'midthickness' surface atlas found for space 'Yerkes19' "
             "(density='32k', hemisphere='left')"
         )
@@ -414,3 +414,108 @@ class TestSurfaceToSurfaceTransformPrivate:
             hemisphere="left",
         )
         assert output == str(tmp_path / "src-A_to-B_den-32k_hemi-L_sphere.surf.gii")
+
+
+class TestTransformSurface:
+    """Unit tests for SurfaceTransformOps.transform_surface."""
+
+    @pytest.fixture
+    def mock_ops(self, graph: NeuromapsGraph) -> NeuromapsGraph:
+        """Mock surface operations."""
+        graph.surface_ops.cache = MagicMock()
+        graph.surface_ops.utils = MagicMock()
+        graph.surface_ops._resolve_sphere_transform = MagicMock()
+        return graph
+
+    @pytest.fixture
+    def basic_params(self, tmp_path: Path) -> dict:
+        """Basic parameters."""
+        input_file = tmp_path / "in.func.gii"
+        input_file.touch()
+        return {
+            "input_file": input_file,
+            "source_space": "fsLR",
+            "target_space": "MNI152",
+            "hemisphere": "left",
+            "output_file_path": str(tmp_path / "out.func.gii"),
+            "source_density": "32k",
+            "target_density": "2mm",
+        }
+
+    @pytest.mark.parametrize("transformer_type", ["metric", "label"])
+    def test_happy_path(
+        self,
+        mock_ops: NeuromapsGraph,
+        basic_params: dict,
+        transformer_type: Literal["metric", "label"],
+        tmp_path: Path,
+    ) -> None:
+        """Metric and label paths call correct resample fn and return output path."""
+        mock_ops.surface_ops._resolve_sphere_transform.return_value = MagicMock(
+            fetch=MagicMock(return_value=tmp_path / "sphere.surf.gii")
+        )
+        mock_ops.surface_ops.cache.require_surface_atlas.return_value = MagicMock(
+            fetch=MagicMock(return_value=tmp_path / "area.surf.gii")
+        )
+        expected_out = tmp_path / "out.func.gii"
+        resample_result = MagicMock(metric_out=expected_out, label_out=expected_out)
+        resample_fn = (
+            "neuromaps_prime.graph.transforms.surface.metric_resample"
+            if transformer_type == "metric"
+            else "neuromaps_prime.graph.transforms.surface.label_resample"
+        )
+        with patch(resample_fn, return_value=resample_result):
+            result = mock_ops.surface_ops.transform_surface(
+                transformer_type=transformer_type, **basic_params
+            )
+        assert result == expected_out
+
+    def test_source_density_estimated_when_none(
+        self, mock_ops: NeuromapsGraph, basic_params: dict, tmp_path: Path
+    ) -> None:
+        """source_density=None triggers estimate_surface_density."""
+        basic_params["source_density"] = None
+        mock_ops.surface_ops._resolve_sphere_transform.return_value = MagicMock()
+        mock_ops.surface_ops.cache.require_surface_atlas.return_value = MagicMock(
+            fetch=MagicMock(return_value=tmp_path / "area.surf.gii")
+        )
+        with (
+            patch(
+                "neuromaps_prime.graph.transforms.surface.estimate_surface_density",
+                return_value="32k",
+            ) as mock_est,
+            patch("neuromaps_prime.graph.transforms.surface.metric_resample"),
+        ):
+            mock_ops.surface_ops.transform_surface(
+                transformer_type="metric", **basic_params
+            )
+        mock_est.assert_called_once_with(basic_params["input_file"])
+
+    def test_target_density_uses_highest_when_none(
+        self, mock_ops: NeuromapsGraph, basic_params: dict, tmp_path: Path
+    ) -> None:
+        """target_density=None calls find_highest_density."""
+        basic_params["target_density"] = None
+        mock_ops.surface_ops._resolve_sphere_transform.return_value = MagicMock()
+        mock_ops.surface_ops.utils.find_highest_density.return_value = "164k"
+        mock_ops.surface_ops.cache.require_surface_atlas.return_value = MagicMock(
+            fetch=MagicMock(return_value=tmp_path / "area.surf.gii")
+        )
+        with patch("neuromaps_prime.graph.transforms.surface.metric_resample"):
+            mock_ops.surface_ops.transform_surface(
+                transformer_type="metric", **basic_params
+            )
+        mock_ops.surface_ops.utils.find_highest_density.assert_called_once_with(
+            space="MNI152"
+        )
+
+    def test_returns_none_when_no_sphere_transform(
+        self, mock_ops: NeuromapsGraph, basic_params: dict
+    ) -> None:
+        """Returns None when _resolve_sphere_transform returns None."""
+        mock_ops.surface_ops._resolve_sphere_transform.return_value = None
+        result = mock_ops.surface_ops.transform_surface(
+            transformer_type="metric", **basic_params
+        )
+        assert result is None
+        mock_ops.surface_ops.cache.require_surface_atlas.assert_not_called()

--- a/tests/unit/graph/transformers/test_surf_to_vol.py
+++ b/tests/unit/graph/transformers/test_surf_to_vol.py
@@ -1,0 +1,160 @@
+"""Tests associated with surface-to-volume transformation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Literal
+
+    from neuromaps_prime.graph import NeuromapsGraph
+
+
+class BasicParams(NamedTuple):
+    """Test param object."""
+
+    input_file: Path
+    ref_volume: Path
+    source_space: str
+    target_space: str
+    hemisphere: Literal["left", "right"]
+    output_file_path: str
+    source_density: str
+    target_density: str | None
+
+
+class TestTransformSurfaceToVolume:
+    """Unit tests for SurfaceTransformOps.transform_surface_to_volume."""
+
+    @pytest.fixture
+    def mock_ops(self, graph: NeuromapsGraph) -> NeuromapsGraph:
+        """Forcefully mock surface operations methods."""
+        graph.surface_ops.cache = MagicMock()
+        graph.surface_ops.utils = MagicMock()
+
+        # This bypasses Pydantic's "object has no field" check
+        object.__setattr__(graph.surface_ops, "transform_surface", MagicMock())
+        return graph
+
+    @pytest.fixture
+    def basic_params(self, tmp_path: Path) -> BasicParams:
+        """Basic parameters for surface-to-volume transformation testing."""
+        input_file = tmp_path / "in.func.gii"
+        input_file.touch()
+        ref_volume = tmp_path / "ref.nii.gz"
+        ref_volume.touch()
+        return BasicParams(
+            input_file=input_file,
+            ref_volume=ref_volume,
+            source_space="fsLR",
+            target_space="MNI152",
+            hemisphere="left",
+            output_file_path=str(tmp_path / "out.nii.gz"),
+            source_density="32k",
+            target_density="2mm",
+        )
+
+    def make_atlas_side_effect(self, tmp_path: Path) -> Callable:
+        """Create a side effect returning valid atlas objects."""
+
+        def get_surface_atlas_side_effect(
+            space: str, density: str, hemisphere: str, resource_type: str
+        ) -> MagicMock:
+            fname = f"space-{space}_den-{density}_hemi-{hemisphere}_{resource_type}"
+            surf_file = tmp_path / f"{fname}.surf.gii"
+            surf_file.touch()
+            return MagicMock(file_path=surf_file)
+
+        return get_surface_atlas_side_effect
+
+    @pytest.mark.parametrize("transformer_type", ["metric", "label"])
+    def test_happy_path(
+        self,
+        mock_ops: NeuromapsGraph,
+        basic_params: BasicParams,
+        transformer_type: Literal["metric", "label"],
+        tmp_path: Path,
+    ) -> None:
+        """Metric and label paths call correct workbench fn and return volume path."""
+        expected_ext = "label.gii" if transformer_type == "label" else "shape.gii"
+        out_surface = tmp_path / f"out.{expected_ext}"
+
+        mock_ops.surface_ops.transform_surface.return_value = out_surface
+        mock_ops.surface_ops.cache.get_surface_atlas.side_effect = (
+            self.make_atlas_side_effect(tmp_path)
+        )
+
+        expected_out = Path(basic_params.output_file_path)
+        wb_fn_name = f"{transformer_type}_to_volume_mapping"
+        wb_patch = f"neuromaps_prime.graph.transforms.surface.workbench.{wb_fn_name}"
+
+        with patch(
+            wb_patch, return_value=MagicMock(volume_out=expected_out)
+        ) as mock_wb:
+            result = mock_ops.surface_ops.transform_surface_to_volume(
+                transformer_type=transformer_type, **basic_params._asdict()
+            )
+
+        assert result == expected_out
+        mock_ops.surface_ops.transform_surface.assert_called_once()
+        assert mock_ops.surface_ops.transform_surface.call_args.kwargs[
+            "output_file_path"
+        ].endswith(expected_ext)
+        mock_wb.assert_called_once()
+
+    def test_target_density_logic(
+        self, mock_ops: NeuromapsGraph, basic_params: BasicParams, tmp_path: Path
+    ) -> None:
+        """Test target_density fallback to highest available when None."""
+        params = basic_params._replace(target_density=None)
+        mock_ops.surface_ops.transform_surface.return_value = tmp_path / "out.shape.gii"
+        mock_ops.surface_ops.utils.find_highest_density.return_value = "164k"
+        mock_ops.surface_ops.cache.get_surface_atlas.side_effect = (
+            self.make_atlas_side_effect(tmp_path)
+        )
+
+        wb_patch = (
+            "neuromaps_prime.graph.transforms.surface.workbench"
+            ".metric_to_volume_mapping"
+        )
+        with patch(
+            wb_patch, return_value=MagicMock(volume_out=tmp_path / "out.nii.gz")
+        ):
+            mock_ops.surface_ops.transform_surface_to_volume(
+                transformer_type="metric", **params._asdict()
+            )
+
+        mock_ops.surface_ops.utils.find_highest_density.assert_called_once_with(
+            space=params.target_space
+        )
+        # Verify get_surface_atlas used the 'highest' density found
+        _, kwargs = mock_ops.surface_ops.cache.get_surface_atlas.call_args
+        assert kwargs["density"] == "164k"
+
+    def test_raises_on_failed_surface_transform(
+        self, mock_ops: NeuromapsGraph, basic_params: BasicParams
+    ) -> None:
+        """FileNotFoundError raised when the intermediate surface transform fails."""
+        mock_ops.surface_ops.transform_surface.return_value = None
+
+        with pytest.raises(FileNotFoundError, match="Unable to perform transformation"):
+            mock_ops.surface_ops.transform_surface_to_volume(
+                transformer_type="metric", **basic_params._asdict()
+            )
+
+    def test_raises_on_missing_target_atlas(
+        self, mock_ops: NeuromapsGraph, basic_params: BasicParams, tmp_path: Path
+    ) -> None:
+        """FileNotFoundError raised when target surface atlas cannot be found."""
+        mock_ops.surface_ops.transform_surface.return_value = tmp_path / "out.shape.gii"
+        mock_ops.surface_ops.cache.get_surface_atlas.return_value = None
+
+        with pytest.raises(FileNotFoundError, match="Unable to find target surface"):
+            mock_ops.surface_ops.transform_surface_to_volume(
+                transformer_type="metric", **basic_params._asdict()
+            )

--- a/tests/unit/graph/transformers/test_vol_to_surf.py
+++ b/tests/unit/graph/transformers/test_vol_to_surf.py
@@ -65,7 +65,7 @@ class TestVolumeToSurfaceTransformer:
     def make_atlas_side_effect(
         self,
         tmp_path: Path,
-        **entities: [str, Literal["left", "right"], str, str],  # noqa: ARG002
+        **entities: dict[str, str],  # noqa: ARG002
     ) -> Callable[[str, Literal["left", "right"], str, str], MagicMock]:
         """Create a side effect returning distinct atlases per resource type."""
 

--- a/tests/unit/graph/transformers/test_vol_to_surf.py
+++ b/tests/unit/graph/transformers/test_vol_to_surf.py
@@ -109,7 +109,7 @@ class TestVolumeToSurfaceTransformer:
                 return_value=projected_file,
             ) as mock_surface_project,
         ):
-            mock_transformer.volume_ops.surface_ops.transform.return_value = (
+            mock_transformer.volume_ops.surface_ops.transform_surface.return_value = (
                 expected_output
             )
             result = mock_transformer.volume_to_surface_transformer(
@@ -122,7 +122,7 @@ class TestVolumeToSurfaceTransformer:
         assert mock_transformer.volume_ops.cache.require_surface_atlas.call_count == 3
         mock_ribbon.assert_called_once()
         mock_surface_project.assert_called_once()
-        mock_transformer.volume_ops.surface_ops.transform.assert_called_once()
+        mock_transformer.volume_ops.surface_ops.transform_surface.assert_called_once()
         assert result == expected_output
 
     @pytest.mark.parametrize(
@@ -144,7 +144,9 @@ class TestVolumeToSurfaceTransformer:
         mock_transformer.volume_ops.cache.require_surface_atlas.side_effect = (
             self.make_atlas_side_effect(tmp_path)
         )
-        mock_transformer.volume_ops.surface_ops.transform.return_value = projected_file
+        mock_transformer.volume_ops.surface_ops.transform_surface.return_value = (
+            projected_file
+        )
         with (
             patch(
                 "neuromaps_prime.graph.transforms.volume.workbench.volume_to_surface_mapping_ribbon_constrained",
@@ -173,7 +175,7 @@ class TestVolumeToSurfaceTransformer:
         mock_transformer.volume_ops.cache.require_surface_atlas.side_effect = (
             self.make_atlas_side_effect(tmp_path)
         )
-        mock_transformer.volume_ops.surface_ops.transform.return_value = Path(
+        mock_transformer.volume_ops.surface_ops.transform_surface.return_value = Path(
             basic_params.output_file_path
         )
 
@@ -188,7 +190,7 @@ class TestVolumeToSurfaceTransformer:
             ),
         ):
             mock_transformer.volume_to_surface_transformer(**basic_params._asdict())
-        mock_transformer.volume_ops.surface_ops.transform.assert_called_once()
+        mock_transformer.volume_ops.surface_ops.transform_surface.assert_called_once()
 
     def test_no_source_surface_atlas(
         self, mock_transformer: NeuromapsGraph, basic_params: BasicParams


### PR DESCRIPTION
Adds additional method to perform `surf2vol` transformations, by applying surface-to-surface transformations if possible (otherwise errors) until final step, before transforming to a volume. 

With this addition, all possible transformations (`surf2surf`, `surf2vol`, `vol2surf`, and `vol2vol`) are all added for basic use cases.

Closes #73 