### PR TITLE
adding receptor notes + references to Yerkes19 annotations

### DIFF
--- a/src/neuromaps_prime/resources/neuromaps_graph.yaml
+++ b/src/neuromaps_prime/resources/neuromaps_graph.yaml
@@ -104,73 +104,101 @@ nodes:
           RMampa:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-ampa_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: AMPA receptor density, radioligand [³H]AMPA. Ionotropic glutamate receptor.
           RMcgp5:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-cgp5_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: GABA_B receptor density, radioligand [³H]CGP54626. Metabotropic inhibitory GABA receptor.
           RMdamp:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-damp_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: M3 muscarinic receptor density, radioligand [³H]4-DAMP. Cholinergic receptor.
           RMdpat:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-dpat_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references: 
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: 5-HT1A receptor density, radioligand [³H]8-OH-DPAT (dpat). Serotonin receptor.
           RMdpmg:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-dpmg_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: D1 dopamine receptor density, radioligand [³H]SCH23390. Dopamine receptor.
           RMflum:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-flum_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: GABA_A/BZ receptor density, radioligand [³H]flumazenil. Benzodiazepine site of GABA_A receptor.
           RMkain:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-kain_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: Kainate receptor density, radioligand [³H]kainate. Ionotropic glutamate receptor.
           RMketa:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-keta_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: 5-HT2A receptor density, radioligand [³H]ketanserin (keta). Serotonin receptor.
           RMmk80:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-mk80_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: NMDA receptor density, radioligand [³H]MK-801 (mk80). Ionotropic glutamate receptor.
           RMmusc:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-musc_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: GABA_A receptor density, radioligand [³H]muscimol. Ionotropic inhibitory GABA receptor.
           RMoxot:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-oxot_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: M2 muscarinic receptor density, radioligand [³H]oxotremorine-M. Cholinergic receptor.
           RMpire:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-pire_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references: 
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: M1 muscarinic receptor density, radioligand [³H]pirenzepine. Cholinergic receptor.
           RMpraz:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-praz_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: α1-adrenergic receptor density, radioligand [³H]prazosin. Noradrenergic receptor.
           RMuk14:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-uk14_desc-RM_annot.func.gii
             right: null
-            references: null
-            notes: null
+            references:
+              - https://doi.org/10.1007/s00429-021-02437-y
+              - https://doi.org/10.1038/s41593-023-01351-2
+            notes: α2-adrenergic receptor density, radioligand [³H]UK-14304 (uk14). Noradrenergic receptor.
     volumes:
       500um:
         T1w: share/Inputs/Yerkes19/src-Yerkes19_res-0p50mm_T1w.nii


### PR DESCRIPTION
adds some brief information about the receptors (biological context & the specific radioligand). 
*original source of files has not been published --> planning to add this reference later

- [ ] confirm the 2 reference papers -- each "reference" section has the same 2 papers. is this redundant? 