### PR TITLE
add Yerkes19 annotation entries with notes and references

### DIFF
--- a/src/neuromaps_prime/resources/neuromaps_graph.yaml
+++ b/src/neuromaps_prime/resources/neuromaps_graph.yaml
@@ -62,7 +62,7 @@ nodes:
           SD:
             left: resources/MEBRAINS/annotations/sulcal_depth/src-MEBRAINS_hemi-L_desc-SD_annot.sulc
             right: resources/MEBRAINS/annotations/sulcal_depth/src-MEBRAINS_hemi-R_desc-SD_annot.sulc
-          
+
     volumes:
       400um:
         T1w: share/Inputs/MEBRAINS/src-MEBRAINS_res-0p40mm_T1w.nii
@@ -90,19 +90,15 @@ nodes:
           PC_MarkovMonkey:
             left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-MarkovMonkey_desc-PC_annot.label.gii
             right: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-MarkovMonkey_desc-PC_annot.label.gii
-            references: null
             notes:
-              - Markov monkey cortical parcellation, 10k surface density.
+            - Markov monkey cortical parcellation, 10k surface density.
           PC_Yeo7Networks:
             left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.label.gii
             right: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-Yeo7Networks_desc-PC_annot.label.gii
-            references: null
-            notes: 
-              - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 10k surface density.
-              - left lookup file -> 
-                resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.txt
-              - right lookup file ->  
-                resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-Yeo7Networks_desc-PC_annot.txt
+            notes:
+            - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 10k surface density.
+            - left lookup file -> resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.txt
+            - right lookup file -> resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-Yeo7Networks_desc-PC_annot.txt
       32k:
         sphere:
           left: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_sphere.surf.gii
@@ -123,133 +119,134 @@ nodes:
           RM_auto_ampa:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-ampa_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - AMPA receptor density, radioligand [³H]AMPA. Ionotropic glutamate receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - AMPA receptor density, radioligand [³H]AMPA. Ionotropic glutamate receptor.
           RM_auto_cgp5:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-cgp5_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
             notes:
-              - GABA_B receptor density, radioligand [³H]CGP54626. Metabotropic inhibitory GABA receptor.
+            - GABA_B receptor density, radioligand [³H]CGP54626. Metabotropic inhibitory GABA receptor.
           RM_auto_damp:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-damp_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - M3 muscarinic receptor density, radioligand [³H]4-DAMP. Cholinergic receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - M3 muscarinic receptor density, radioligand [³H]4-DAMP. Cholinergic receptor.
           RM_auto_dpat:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-dpat_desc-RM_annot.func.gii
-            references: 
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - 5-HT1A receptor density, radioligand [³H]8-OH-DPAT. Serotonin receptor.
+            references:
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - 5-HT1A receptor density, radioligand [³H]8-OH-DPAT. Serotonin receptor.
           RM_auto_dpmg:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-dpmg_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - D1 dopamine receptor density, radioligand [³H]SCH23390. Dopamine receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - D1 dopamine receptor density, radioligand [³H]SCH23390. Dopamine receptor.
           RM_auto_flum:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-flum_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - GABA_A/BZ receptor density, radioligand [³H]flumazenil. Benzodiazepine site of GABA_A receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - GABA_A/BZ receptor density, radioligand [³H]flumazenil. Benzodiazepine site of GABA_A receptor.
           RM_auto_kain:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-kain_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - Kainate receptor density, radioligand [³H]kainate. Ionotropic glutamate receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - Kainate receptor density, radioligand [³H]kainate. Ionotropic glutamate receptor.
           RM_auto_keta:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-keta_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - 5-HT2A receptor density, radioligand [³H]ketanserin. Serotonin receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - 5-HT2A receptor density, radioligand [³H]ketanserin. Serotonin receptor.
           RM_auto_mk80:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-mk80_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - NMDA receptor density, radioligand [³H]MK-801. Ionotropic glutamate receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - NMDA receptor density, radioligand [³H]MK-801. Ionotropic glutamate receptor.
           RM_auto_musc:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-musc_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - GABA_A receptor density, radioligand [³H]muscimol. Ionotropic inhibitory GABA receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - GABA_A receptor density, radioligand [³H]muscimol. Ionotropic inhibitory GABA receptor.
           RM_auto_oxot:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-oxot_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - M2 muscarinic receptor density, radioligand [³H]oxotremorine-M. Cholinergic receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - M2 muscarinic receptor density, radioligand [³H]oxotremorine-M. Cholinergic receptor.
           RM_auto_pire:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-pire_desc-RM_annot.func.gii
-            references: 
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - M1 muscarinic receptor density, radioligand [³H]pirenzepine. Cholinergic receptor.
+            references:
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - M1 muscarinic receptor density, radioligand [³H]pirenzepine. Cholinergic receptor.
           RM_auto_praz:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-praz_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - α1-adrenergic receptor density, radioligand [³H]prazosin. Noradrenergic receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - α1-adrenergic receptor density, radioligand [³H]prazosin. Noradrenergic receptor.
           RM_auto_uk14:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-uk14_desc-RM_annot.func.gii
             references:
-              - https://doi.org/10.1007/s00429-021-02437-y
-              - https://doi.org/10.1038/s41593-023-01351-2
-            notes: 
-              - α2-adrenergic receptor density, radioligand [³H]UK-14304. Noradrenergic receptor.
+            - https://doi.org/10.1007/s00429-021-02437-y
+            - https://doi.org/10.1038/s41593-023-01351-2
+            notes:
+            - α2-adrenergic receptor density, radioligand [³H]UK-14304. Noradrenergic receptor.
           MM:
             left: resources/Yerkes19/annotations/myelin_maps/src-Yerkes19_den-32k_hemi-L_desc-MM_annot.func.gii
             right: resources/Yerkes19/annotations/myelin_maps/src-Yerkes19_den-32k_hemi-R_desc-MM_annot.func.gii
-            references: 
-              - https://doi.org/10.1073/pnas.1721653115
-            notes: Myelin map (bias corrected). MacaqueYerkes19 v1.2.
+            references:
+            - https://doi.org/10.1073/pnas.1721653115
+            notes:
+            - Myelin map (bias corrected). MacaqueYerkes19 v1.2.
           SMM:
             left: resources/Yerkes19/annotations/smoothed_myelin_maps/src-Yerkes19_den-32k_hemi-L_desc-SMM_annot.func.gii
             right: resources/Yerkes19/annotations/smoothed_myelin_maps/src-Yerkes19_den-32k_hemi-R_desc-SMM_annot.func.gii
-            references: 
-              - https://doi.org/10.1073/pnas.1721653115
-            notes: Smoothed myelin map (bias corrected). MacaqueYerkes19 v1.2.
+            references:
+            - https://doi.org/10.1073/pnas.1721653115
+            notes:
+            - Smoothed myelin map (bias corrected). MacaqueYerkes19 v1.2.
           CT:
             left: resources/Yerkes19/annotations/cortical_thickness/src-Yerkes19_den-32k_hemi-L_desc-CT_annot.func.gii
             right: resources/Yerkes19/annotations/cortical_thickness/src-Yerkes19_den-32k_hemi-R_desc-CT_annot.func.gii
-            references: 
-              - https://doi.org/10.1073/pnas.1721653115
-            notes: Cortical thickness. MacaqueYerkes19 v1.2.
+            references:
+            - https://doi.org/10.1073/pnas.1721653115
+            notes:
+            - Cortical thickness. MacaqueYerkes19 v1.2.
           CV:
             left: resources/Yerkes19/annotations/curvature/src-Yerkes19_den-32k_hemi-L_desc-CV_annot.func.gii
             right: resources/Yerkes19/annotations/curvature/src-Yerkes19_den-32k_hemi-R_desc-CV_annot.func.gii
-            references: 
-              - https://doi.org/10.1073/pnas.1721653115
-            notes: Curvature. MacaqueYerkes19 v1.2.
+            references:
+            - https://doi.org/10.1073/pnas.1721653115
+            notes:
+            - Curvature. MacaqueYerkes19 v1.2.
           PC_Yeo7Networks:
             left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-32k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.label.gii
-            right: null
-            references: null
-            notes: 
-              - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 32k surface density.
-              - left lookup file -> 
-                resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-32k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.txt
+            notes:
+            - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 32k surface density.
+            - left lookup file -> resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-32k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.txt
     volumes:
       500um:
         T1w: share/Inputs/Yerkes19/src-Yerkes19_res-0p50mm_T1w.nii

--- a/src/neuromaps_prime/resources/neuromaps_graph.yaml
+++ b/src/neuromaps_prime/resources/neuromaps_graph.yaml
@@ -87,9 +87,22 @@ nodes:
           left: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_inflated.surf.gii
           right: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-R_inflated.surf.gii
         annotation:
+          PC_MarkovMonkey:
+            left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-MarkovMonkey_desc-PC_annot.label.gii
+            right: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-MarkovMonkey_desc-PC_annot.label.gii
+            references: null
+            notes:
+              - Markov monkey cortical parcellation, 10k surface density.
           PC_Yeo7Networks:
             left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.label.gii
             right: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-Yeo7Networks_desc-PC_annot.label.gii
+            references: null
+            notes: 
+              - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 10k surface density.
+              - left lookup file -> 
+                resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.txt
+              - right lookup file ->  
+                resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-Yeo7Networks_desc-PC_annot.txt
       32k:
         sphere:
           left: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_sphere.surf.gii
@@ -134,7 +147,7 @@ nodes:
               - https://doi.org/10.1007/s00429-021-02437-y
               - https://doi.org/10.1038/s41593-023-01351-2
             notes: 
-              - 5-HT1A receptor density, radioligand [³H]8-OH-DPAT (dpat). Serotonin receptor.
+              - 5-HT1A receptor density, radioligand [³H]8-OH-DPAT. Serotonin receptor.
           RM_auto_dpmg:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-dpmg_desc-RM_annot.func.gii
             references:
@@ -162,14 +175,14 @@ nodes:
               - https://doi.org/10.1007/s00429-021-02437-y
               - https://doi.org/10.1038/s41593-023-01351-2
             notes: 
-              - 5-HT2A receptor density, radioligand [³H]ketanserin (keta). Serotonin receptor.
+              - 5-HT2A receptor density, radioligand [³H]ketanserin. Serotonin receptor.
           RM_auto_mk80:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-mk80_desc-RM_annot.func.gii
             references:
               - https://doi.org/10.1007/s00429-021-02437-y
               - https://doi.org/10.1038/s41593-023-01351-2
             notes: 
-              - NMDA receptor density, radioligand [³H]MK-801 (mk80). Ionotropic glutamate receptor.
+              - NMDA receptor density, radioligand [³H]MK-801. Ionotropic glutamate receptor.
           RM_auto_musc:
             left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-musc_desc-RM_annot.func.gii
             references:
@@ -204,24 +217,39 @@ nodes:
               - https://doi.org/10.1007/s00429-021-02437-y
               - https://doi.org/10.1038/s41593-023-01351-2
             notes: 
-              - α2-adrenergic receptor density, radioligand [³H]UK-14304 (uk14). Noradrenergic receptor.
+              - α2-adrenergic receptor density, radioligand [³H]UK-14304. Noradrenergic receptor.
           MM:
             left: resources/Yerkes19/annotations/myelin_maps/src-Yerkes19_den-32k_hemi-L_desc-MM_annot.func.gii
             right: resources/Yerkes19/annotations/myelin_maps/src-Yerkes19_den-32k_hemi-R_desc-MM_annot.func.gii
+            references: 
+              - https://doi.org/10.1073/pnas.1721653115
+            notes: Myelin map (bias corrected). MacaqueYerkes19 v1.2.
           SMM:
             left: resources/Yerkes19/annotations/smoothed_myelin_maps/src-Yerkes19_den-32k_hemi-L_desc-SMM_annot.func.gii
             right: resources/Yerkes19/annotations/smoothed_myelin_maps/src-Yerkes19_den-32k_hemi-R_desc-SMM_annot.func.gii
+            references: 
+              - https://doi.org/10.1073/pnas.1721653115
+            notes: Smoothed myelin map (bias corrected). MacaqueYerkes19 v1.2.
           CT:
             left: resources/Yerkes19/annotations/cortical_thickness/src-Yerkes19_den-32k_hemi-L_desc-CT_annot.func.gii
             right: resources/Yerkes19/annotations/cortical_thickness/src-Yerkes19_den-32k_hemi-R_desc-CT_annot.func.gii
+            references: 
+              - https://doi.org/10.1073/pnas.1721653115
+            notes: Cortical thickness. MacaqueYerkes19 v1.2.
           CV:
             left: resources/Yerkes19/annotations/curvature/src-Yerkes19_den-32k_hemi-L_desc-CV_annot.func.gii
             right: resources/Yerkes19/annotations/curvature/src-Yerkes19_den-32k_hemi-R_desc-CV_annot.func.gii
-          PC_MarkovMonkey:
-            left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-MarkovMonkey_desc-PC_annot.label.gii
-            right: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-MarkovMonkey_desc-PC_annot.label.gii
+            references: 
+              - https://doi.org/10.1073/pnas.1721653115
+            notes: Curvature. MacaqueYerkes19 v1.2.
           PC_Yeo7Networks:
             left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-32k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.label.gii
+            right: null
+            references: null
+            notes: 
+              - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 32k surface density.
+              - left lookup file -> 
+                resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-32k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.txt
     volumes:
       500um:
         T1w: share/Inputs/Yerkes19/src-Yerkes19_res-0p50mm_T1w.nii


### PR DESCRIPTION
- [X]  Organized annotation entries under `10k` and `32k` surface densities
- [X]  Added lookup `.txt` file paths under `notes:` for `PC_Yeo7Networks`
- [X]  Added `references:` and `notes:` where applicable
- [X]  Set `null` for empty or unused fields