### PR TITLE
Add remote URIs for nodes and edges

### DIFF
--- a/src/neuromaps_prime/resources/edges/surface/human_chimpanzee.yaml
+++ b/src/neuromaps_prime/resources/edges/surface/human_chimpanzee.yaml
@@ -1,0 +1,20 @@
+- from: NCBR
+  to: fsaverage
+  surfaces:
+    human_chimpanzee:
+      164k:
+        sphere:
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a15f5137ef401e8b5cc76a8/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a15f506bfa98ff448cc76a0/?view_only=b214f40525fe44b5bea3103478d08d0d
+        white:
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a15f507912b4551c17ee3fe/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a15f50ca576658b627ee412/?view_only=b214f40525fe44b5bea3103478d08d0d
+
+- from: fsaverage
+  to: NCBR
+  surfaces:
+    human_chimpanzee:
+      164k:
+        sphere:
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a15f53c00e86708937eeae1/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a15f543912b4551c17ee412/?view_only=b214f40525fe44b5bea3103478d08d0d

--- a/src/neuromaps_prime/resources/edges/surface/human_macaque.yaml
+++ b/src/neuromaps_prime/resources/edges/surface/human_macaque.yaml
@@ -4,18 +4,18 @@
     human_macaque:
       10k:
         midthickness:
-          left: share/Outputs/S1200-Yerkes19/src-Yerkes19_to-S1200_den-10k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/S1200-Yerkes19/src-Yerkes19_to-S1200_den-10k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4b999b6fa812c2b8cc7c/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4b981e78bf36907df9d8/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/S1200-Yerkes19/src-Yerkes19_to-S1200_den-10k_hemi-L_sphere.surf.gii
-          right: share/Outputs/S1200-Yerkes19/src-Yerkes19_to-S1200_den-10k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4b99b422df79d9b8c810/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4b98e81de16f937df329/?view_only=b214f40525fe44b5bea3103478d08d0d
       32k:
         midthickness:
-          left: share/Outputs/fsLR-Yerkes19/src-Yerkes19_to-fsLR_den-32k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/fsLR-Yerkes19/src-Yerkes19_to-fsLR_den-32k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4b99e81de16f937df32b/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4b991e78bf36907df9de/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/S1200-Yerkes19/src-Yerkes19_to-S1200_den-32k_hemi-L_sphere.surf.gii
-          right: share/Outputs/S1200-Yerkes19/src-Yerkes19_to-S1200_den-32k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4b989b6fa812c2b8cc7a/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4b99f44e0687016b9f1b/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: fsLR
   to: Yerkes19
@@ -23,15 +23,15 @@
     human_macaque:
       10k:
         midthickness:
-          left: share/Outputs/Yerkes19-S1200/src-S1200_to-Yerkes19_den-10k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/Yerkes19-S1200/src-S1200_to-Yerkes19_den-10k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d34f562d9ece2b8c75e/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d3497f5a8d6e96b9bed/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/Yerkes19-S1200/src-S1200_to-Yerkes19_den-10k_hemi-L_sphere.surf.gii
-          right: share/Outputs/Yerkes19-S1200/src-S1200_to-Yerkes19_den-10k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d359b6fa812c2b8cd05/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d349b6fa812c2b8cd04/?view_only=b214f40525fe44b5bea3103478d08d0d
       32k:
         midthickness:
-          left: share/Outputs/Yerkes19-fsLR/src-fsLR_to-Yerkes19_den-32k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/Yerkes19-fsLR/src-fsLR_to-Yerkes19_den-32k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a20477165f69cffb350349b/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d35e81de16f937df3c8/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/Yerkes19-S1200/src-S1200_to-Yerkes19_den-32k_hemi-L_sphere.surf.gii
-          right: share/Outputs/Yerkes19-S1200/src-S1200_to-Yerkes19_den-32k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d531e78bf36907dfa59/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d35e81de16f937df3c9/?view_only=b214f40525fe44b5bea3103478d08d0d

--- a/src/neuromaps_prime/resources/edges/surface/macaque_macaque.yaml
+++ b/src/neuromaps_prime/resources/edges/surface/macaque_macaque.yaml
@@ -4,11 +4,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/D99-CIVETNMT/src-CIVETNMT_to-D99_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/D99-CIVETNMT/src-CIVETNMT_to-D99_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f43fef44e0687016b9b34/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f43feb5295c553db8cc95/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/D99-CIVETNMT/src-CIVETNMT_to-D99_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/D99-CIVETNMT/src-CIVETNMT_to-D99_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f43feb5295c553db8cc96/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f43fec63a718cdfb8d0c6/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: CIVETNMT
   to: MEBRAINS
@@ -16,11 +16,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/MEBRAINS-CIVETNMT/src-CIVETNMT_to-MEBRAINS_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/MEBRAINS-CIVETNMT/src-CIVETNMT_to-MEBRAINS_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f470c4cf949e3cd7df8f3/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f470dedf908b2217df2c2/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/MEBRAINS-CIVETNMT/src-CIVETNMT_to-MEBRAINS_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/MEBRAINS-CIVETNMT/src-CIVETNMT_to-MEBRAINS_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f470cd4be03f6846ba1a3/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f470d1e78bf36907df619/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: CIVETNMT
   to: NMT2Sym
@@ -28,11 +28,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/NMT2Sym-CIVETNMT/src-CIVETNMT_to-NMT2Sym_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/NMT2Sym-CIVETNMT/src-CIVETNMT_to-NMT2Sym_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f48fc2b160b523a6ba074/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f48fa4cf949e3cd7df98f/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/NMT2Sym-CIVETNMT/src-CIVETNMT_to-NMT2Sym_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/NMT2Sym-CIVETNMT/src-CIVETNMT_to-NMT2Sym_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f48fad4be03f6846ba241/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f48fbedf908b2217df3d4/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: CIVETNMT
   to: Yerkes19
@@ -40,11 +40,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/Yerkes19-CIVETNMT/src-CIVETNMT_to-Yerkes19_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/Yerkes19-CIVETNMT/src-CIVETNMT_to-Yerkes19_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4bae4cf949e3cd7dfa37/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4bae97f5a8d6e96b9b87/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/Yerkes19-CIVETNMT/src-CIVETNMT_to-Yerkes19_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/Yerkes19-CIVETNMT/src-CIVETNMT_to-Yerkes19_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4badf44e0687016b9f1d/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4bae4ec6fad47d6b998a/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: D99
   to: CIVETNMT
@@ -52,11 +52,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/CIVETNMT-D99/src-D99_to-CIVETNMT_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/CIVETNMT-D99/src-D99_to-CIVETNMT_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f433ab30df7012c7df8cb/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f433a3a67df4a7bb8cbca/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/CIVETNMT-D99/src-D99_to-CIVETNMT_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/CIVETNMT-D99/src-D99_to-CIVETNMT_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f43384e6a7ca98db8cc12/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f433aa48132c37f6b99b6/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: D99
   to: MEBRAINS
@@ -64,11 +64,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/MEBRAINS-D99/src-D99_to-MEBRAINS_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/MEBRAINS-D99/src-D99_to-MEBRAINS_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f472bedf908b2217df2cc/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f472b2b297b6deab8c9d4/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/MEBRAINS-D99/src-D99_to-MEBRAINS_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/MEBRAINS-D99/src-D99_to-MEBRAINS_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f472ad4be03f6846ba1b4/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f472bd4be03f6846ba1b6/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: D99
   to: NMT2Sym
@@ -76,11 +76,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/NMT2Sym-D99/src-D99_to-NMT2Sym_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/NMT2Sym-D99/src-D99_to-NMT2Sym_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f491b2b297b6deab8ca27/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f491bedf908b2217df3db/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/NMT2Sym-D99/src-D99_to-NMT2Sym_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/NMT2Sym-D99/src-D99_to-NMT2Sym_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f491a97f5a8d6e96b9aca/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f491ac63a718cdfb8d2ea/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: D99
   to: Yerkes19
@@ -88,11 +88,12 @@
     CIVET:
       32k:
         midthickness:
-          left: share/Outputs/Yerkes19-D99/src-D99_to-Yerkes19_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/Yerkes19-D99/src-D99_to-Yerkes19_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4bc8b422df79d9b8c824/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4bcaf44e0687016b9f2d/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/Yerkes19-D99/src-D99_to-Yerkes19_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/Yerkes19-D99/src-D99_to-Yerkes19_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4bca2b297b6deab8cab6/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4bcae81de16f937df33a/?view_only=b214f40525fe44b5bea3103478d08d0d
+
 
 - from: MEBRAINS
   to: CIVETNMT
@@ -100,11 +101,11 @@
     CIVET:
       101k:
         midthickness:
-          left: share/Outputs/CIVETNMT-MEBRAINS/src-MEBRAINS_to-CIVETNMT_den-101k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/CIVETNMT-MEBRAINS/src-MEBRAINS_to-CIVETNMT_den-101k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4356b5295c553db8cc5d/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f43561e78bf36907df481/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/CIVETNMT-MEBRAINS/src-MEBRAINS_to-CIVETNMT_den-101k_hemi-L_sphere.surf.gii
-          right: share/Outputs/CIVETNMT-MEBRAINS/src-MEBRAINS_to-CIVETNMT_den-101k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f43551e78bf36907df47e/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4357babb8ee8a47df6db/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: MEBRAINS
   to: D99
@@ -112,11 +113,11 @@
     CIVET:
       101k:
         midthickness:
-          left: share/Outputs/D99-MEBRAINS/src-MEBRAINS_to-D99_den-101k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/D99-MEBRAINS/src-MEBRAINS_to-D99_den-101k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f442cf44e0687016b9b64/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f442db5295c553db8cccf/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/D99-MEBRAINS/src-MEBRAINS_to-D99_den-101k_hemi-L_sphere.surf.gii
-          right: share/Outputs/D99-MEBRAINS/src-MEBRAINS_to-D99_den-101k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f442d4e6a7ca98db8cc3a/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f442cb30df7012c7df90f/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: MEBRAINS
   to: NMT2Sym
@@ -124,11 +125,11 @@
     CIVET:
       101k:
         midthickness:
-          left: share/Outputs/NMT2Sym-MEBRAINS/src-MEBRAINS_to-NMT2Sym_den-101k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/NMT2Sym-MEBRAINS/src-MEBRAINS_to-NMT2Sym_den-101k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f49f93a67df4a7bb8cdd7/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f49fa1e78bf36907df73a/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/NMT2Sym-MEBRAINS/src-MEBRAINS_to-NMT2Sym_den-101k_hemi-L_sphere.surf.gii
-          right: share/Outputs/NMT2Sym-MEBRAINS/src-MEBRAINS_to-NMT2Sym_den-101k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f49fa3a67df4a7bb8cdda/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f49f92b160b523a6ba0cc/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: MEBRAINS
   to: Yerkes19
@@ -136,11 +137,11 @@
     CIVET:
       101k:
         midthickness:
-          left: share/Outputs/Yerkes19-MEBRAINS/src-MEBRAINS_to-Yerkes19_den-101k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/Yerkes19-MEBRAINS/src-MEBRAINS_to-Yerkes19_den-101k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4c5b97f5a8d6e96b9bc5/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4c5d2b160b523a6ba17a/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/Yerkes19-MEBRAINS/src-MEBRAINS_to-Yerkes19_den-101k_hemi-L_sphere.surf.gii
-          right: share/Outputs/Yerkes19-MEBRAINS/src-MEBRAINS_to-Yerkes19_den-101k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4c5e97f5a8d6e96b9bc7/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4c5db422df79d9b8c840/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: NMT2Sym
   to: CIVETNMT
@@ -148,11 +149,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/CIVETNMT-NMT2Sym/src-NMT2Sym_to-CIVETNMT_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/CIVETNMT-NMT2Sym/src-NMT2Sym_to-CIVETNMT_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4376ff98819c6e7df40d/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4376f44e0687016b9b24/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/CIVETNMT-NMT2Sym/src-NMT2Sym_to-CIVETNMT_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/CIVETNMT-NMT2Sym/src-NMT2Sym_to-CIVETNMT_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f43760ad6228a4a6b9bb2/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4376b30df7012c7df8d5/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: NMT2Sym
   to: D99
@@ -160,11 +161,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/D99-NMT2Sym/src-NMT2Sym_to-D99_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/D99-NMT2Sym/src-NMT2Sym_to-D99_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f44a42b160b523a6b9eb5/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f44a5c63a718cdfb8d0ff/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/D99-NMT2Sym/src-NMT2Sym_to-D99_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/D99-NMT2Sym/src-NMT2Sym_to-D99_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f44a5f44e0687016b9bb0/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f44a54cf949e3cd7df833/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: NMT2Sym
   to: MEBRAINS
@@ -172,11 +173,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/MEBRAINS-NMT2Sym/src-NMT2Sym_to-MEBRAINS_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/MEBRAINS-NMT2Sym/src-NMT2Sym_to-MEBRAINS_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f47b1c63a718cdfb8d229/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f47b1f44e0687016b9d02/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/MEBRAINS-NMT2Sym/src-NMT2Sym_to-MEBRAINS_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/MEBRAINS-NMT2Sym/src-NMT2Sym_to-MEBRAINS_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f47b01e78bf36907df65b/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f47b13a67df4a7bb8cd38/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: NMT2Sym
   to: Yerkes19
@@ -184,11 +185,11 @@
     CIVET:
       41k:
         midthickness:
-          left: share/Outputs/Yerkes19-NMT2Sym/src-NMT2Sym_to-Yerkes19_den-41k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/Yerkes19-NMT2Sym/src-NMT2Sym_to-Yerkes19_den-41k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f47b1c63a718cdfb8d229/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d2bb422df79d9b8c8f1/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/Yerkes19-NMT2Sym/src-NMT2Sym_to-Yerkes19_den-41k_hemi-L_sphere.surf.gii
-          right: share/Outputs/Yerkes19-NMT2Sym/src-NMT2Sym_to-Yerkes19_den-41k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d353e6dfd1a99b8c771/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d359bf888fc296b991e/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: Yerkes19
   to: CIVETNMT
@@ -196,11 +197,11 @@
     CIVET:
       32k:
         midthickness:
-          left: share/Outputs/CIVETNMT-Yerkes19/src-yerkes19_to-CIVETNMT_den-32k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/CIVETNMT-Yerkes19/src-yerkes19_to-CIVETNMT_den-32k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f438cb30df7012c7df8d7/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f438fd4be03f6846ba0a8/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/CIVETNMT-Yerkes19/src-yerkes19_to-CIVETNMT_den-32k_hemi-L_sphere.surf.gii
-          right: share/Outputs/CIVETNMT-Yerkes19/src-yerkes19_to-CIVETNMT_den-32k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f438e2b160b523a6b9dfc/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f438db5295c553db8cc6c/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: Yerkes19
   to: D99
@@ -208,11 +209,11 @@
     CIVET:
       32k:
         midthickness:
-          left: share/Outputs/D99-Yerkes19/src-Yerkes19_to-D99_den-32k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/D99-Yerkes19/src-Yerkes19_to-D99_den-32k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f45b1c63a718cdfb8d191/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f45afbabb8ee8a47df79f/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/D99-Yerkes19/src-Yerkes19_to-D99_den-32k_hemi-L_sphere.surf.gii
-          right: share/Outputs/D99-Yerkes19/src-Yerkes19_to-D99_den-32k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f45afb30df7012c7df9bf/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f45b1f44e0687016b9c69/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: Yerkes19
   to: MEBRAINS
@@ -220,11 +221,11 @@
     CIVET:
       32k:
         midthickness:
-          left: share/Outputs/MEBRAINS-Yerkes19/src-yerkes19_to-MEBRAINS_den-32k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/MEBRAINS-Yerkes19/src-yerkes19_to-MEBRAINS_den-32k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f48633a67df4a7bb8cd73/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4863c63a718cdfb8d2b5/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/MEBRAINS-Yerkes19/src-yerkes19_to-MEBRAINS_den-32k_hemi-L_sphere.surf.gii
-          right: share/Outputs/MEBRAINS-Yerkes19/src-yerkes19_to-MEBRAINS_den-32k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4862babb8ee8a47df845/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f48634cf949e3cd7df956/?view_only=b214f40525fe44b5bea3103478d08d0d
 
 - from: Yerkes19
   to: NMT2Sym
@@ -232,8 +233,8 @@
     CIVET:
       32k:
         midthickness:
-          left: share/Outputs/NMT2Sym-Yerkes19/src-yerkes19_to-NMT2Sym_den-32k_hemi-L_midthickness.surf.gii
-          right: share/Outputs/NMT2Sym-Yerkes19/src-yerkes19_to-NMT2Sym_den-32k_hemi-R_midthickness.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4abbedf908b2217df52d/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4abc2b297b6deab8ca7f/?view_only=b214f40525fe44b5bea3103478d08d0d
         sphere:
-          left: share/Outputs/NMT2Sym-Yerkes19/src-yerkes19_to-NMT2Sym_den-32k_hemi-L_sphere.surf.gii
-          right: share/Outputs/NMT2Sym-Yerkes19/src-yerkes19_to-NMT2Sym_den-32k_hemi-R_sphere.surf.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4abcedf908b2217df52f/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4abc1e78bf36907df879/?view_only=b214f40525fe44b5bea3103478d08d0d

--- a/src/neuromaps_prime/resources/edges/volume/macaque_macaque.yaml
+++ b/src/neuromaps_prime/resources/edges/volume/macaque_macaque.yaml
@@ -3,70 +3,70 @@
   volumes:
     RheMap:
       500um:
-        composite: share/Outputs/Yerkes19-MEBRAINS/src-MEBRAINS_to-Yerkes19_res-0p50mm_mode-image_desc-Composite.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4cc74ec6fad47d6b9a32/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: MEBRAINS
   to: D99
   volumes:
     RheMap:
       250um:
-        composite: share/Outputs/D99-MEBRAINS/src-MEBRAINS_to-D99_res-0p25mm_mode-image_desc-Composite.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4485b30df7012c7df93b/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: MEBRAINS
   to: NMT2Sym
   volumes:
     RheMap:
       250um:
-        composite: share/Outputs/NMT2Sym-MEBRAINS/src-MEBRAINS_to-NMT2Sym_res-0p25mm_mode-image_desc-Composite.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4a8fedf908b2217df529/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: D99
   to: MEBRAINS
   volumes:
     RheMap:
       400um:
-        composite: share/Outputs/MEBRAINS-D99/src-D99_to-MEBRAINS_res-0p40mm_mode-image_desc-Composite.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4784d4be03f6846ba1df/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: D99
   to: NMT2Sym
   volumes:
     RheMap:
       250um:
-        composite: share/Outputs/D99-NMT2Sym/src-NMT2Sym_to-D99_res-0p25mm_mode-image_desc-Composite_xfm.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f49cef44e0687016b9d7f/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: D99
   to: Yerkes19
   volumes:
     RheMap:
       250um:
-        composite: share/Outputs/D99-Yerkes19/src-Yerkes19_to-D99_res-0p25mm_mode-image_desc-Composite_xfm.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4c241e78bf36907dfa17/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: NMT2Sym
   to: MEBRAINS
   volumes:
     RheMap:
       400um:
-        composite: share/Outputs/MEBRAINS-NMT2Sym/src-NMT2Sym_to-MEBRAINS_res-0p40mm_mode-image_desc-Composite.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4801d4be03f6846ba1fc/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: NMT2Sym
   to: D99
   volumes:
     RheMap:
       250um:
-        composite: share/Outputs/NMT2Sym-D99/src-D99_to-NMT2Sym_res-0p25mm_mode-image_desc-Composite_xfm.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f45904cf949e3cd7df899/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: NMT2Sym
   to: Yerkes19
   volumes:
     RheMap:
       250um:
-        composite: share/Outputs/NMT2Sym-Yerkes19/src-Yerkes19_to-NMT2Sym_res-0p25mm_mode-image_desc-Composite_xfm.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4d4daa01d3aabe3935e6/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: Yerkes19
   to: MEBRAINS
   volumes:
     RheMap:
       400um:
-        composite: share/Outputs/MEBRAINS-Yerkes19/src-Yerkes19_to-MEBRAINS_res-0p40mm_mode-image_desc-Composite.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f48b4f44e0687016b9d54/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: Yerkes19
   to: D99
   volumes:
     RheMap:
       250um:
-        composite: share/Outputs/Yerkes19-D99/src-D99_to-Yerkes19_res-0p25mm_mode-image_desc-Composite_xfm.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f46b9c63a718cdfb8d1d2/?view_only=b214f40525fe44b5bea3103478d08d0d
 - from: Yerkes19
   to: NMT2Sym
   volumes:
     RheMap:
       250um:
-        composite: share/Outputs/Yerkes19-NMT2Sym/src-NMT2Sym_to-Yerkes19_res-0p25mm_mode-image_desc-Composite_xfm.nii.gz
+        composite: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a1f4b719b6fa812c2b8cc6d/?view_only=b214f40525fe44b5bea3103478d08d0d

--- a/src/neuromaps_prime/resources/nodes/human/fsLR.yaml
+++ b/src/neuromaps_prime/resources/nodes/human/fsLR.yaml
@@ -5,37 +5,37 @@ fsLR:
     10k:
       # 10K surfaces all use https://github.com/TingsterX/alignment_macaque-human
       sphere:
-        left: share/Inputs/S1200/src-S1200_den-10k_hemi-L_sphere.surf.gii
-        right: share/Inputs/S1200/src-S1200_den-10k_hemi-R_sphere.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5240123e17e1124712d02/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523fec807054314902be0/?view_only=b214f40525fe44b5bea3103478d08d0d
       midthickness:
-        left: share/Inputs/S1200/src-S1200_den-10k_hemi-L_midthickness.surf.gii
-        right: share/Inputs/S1200/src-S1200_den-10k_hemi-R_midthickness.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d524032882bdb2bc3ebf0c/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523fe4d366de13d71404b/?view_only=b214f40525fe44b5bea3103478d08d0d
       white:
-        left: share/Inputs/S1200/src-S1200_den-10k_hemi-L_white.surf.gii
-        right: share/Inputs/S1200/src-S1200_den-10k_hemi-R_white.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52401aa1f78e19790364c/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523ffa52f9bb389712bee/?view_only=b214f40525fe44b5bea3103478d08d0d
       pial:
-        left: share/Inputs/S1200/src-S1200_den-10k_hemi-L_pial.surf.gii
-        right: share/Inputs/S1200/src-S1200_den-10k_hemi-R_pial.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52403c807054314902bf2/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d524036846076e8371381f/?view_only=b214f40525fe44b5bea3103478d08d0d
       inflated:
-        left: share/Inputs/S1200/src-S1200_den-10k_hemi-L_inflated.surf.gii
-        right: share/Inputs/S1200/src-S1200_den-10k_hemi-R_inflated.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52401ab76e18c73904630/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d524004d366de13d71404e/?view_only=b214f40525fe44b5bea3103478d08d0d
     32k:
     # 32k inflated and midthickness from neuromaps, otherwise same as 10k source
       sphere:
-        left: share/Inputs/S1200/src-S1200_den-32k_hemi-L_sphere.surf.gii
-        right: share/Inputs/S1200/src-S1200_den-32k_hemi-R_sphere.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523fe2882bdb2bc3ebf00/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523fd2882bdb2bc3ebefd/?view_only=b214f40525fe44b5bea3103478d08d0d
       midthickness:
-        left: share/Inputs/fsLR/src-fsLR_den-32k_hemi-L_midthickness.surf.gii
-        right: share/Inputs/fsLR/src-fsLR_den-32k_hemi-R_midthickness.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523542882bdb2bc3ebe33/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5235ae06110211c3ead48/?view_only=b214f40525fe44b5bea3103478d08d0d
       white:
-        left: share/Inputs/S1200/src-S1200_den-32k_hemi-L_white.surf.gii
-        right: share/Inputs/S1200/src-S1200_den-32k_hemi-R_white.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5240149b4c2d6503eccbe/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523ff49b4c2d6503eccb5/?view_only=b214f40525fe44b5bea3103478d08d0d
       pial:
-        left: share/Inputs/S1200/src-S1200_den-32k_hemi-L_pial.surf.gii
-        right: share/Inputs/S1200/src-S1200_den-32k_hemi-R_pial.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523fda52f9bb389712bec/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523fdab76e18c7390462c/?view_only=b214f40525fe44b5bea3103478d08d0d
       inflated:
-        left: share/Inputs/fsLR/src-fsLR_den-32k_hemi-L_inflated.surf.gii
-        right: share/Inputs/fsLR/src-fsLR_den-32k_hemi-R_inflated.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52353743de820043ead85/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52354743de820043ead87/?view_only=b214f40525fe44b5bea3103478d08d0d
       flat:
-        left: share/Inputs/S1200/src-S1200_den-32k_hemi-L_flat.surf.gii
-        right: share/Inputs/S1200/src-S1200_den-32k_hemi-R_flat.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5240049b4c2d6503eccb7/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d524006846076e8371381c/?view_only=b214f40525fe44b5bea3103478d08d0d

--- a/src/neuromaps_prime/resources/nodes/macaque/CIVETNMT.yaml
+++ b/src/neuromaps_prime/resources/nodes/macaque/CIVETNMT.yaml
@@ -4,11 +4,11 @@ CIVETNMT:
   surfaces:
     41k:
       sphere:
-        left: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-L_sphere.surf.gii
-        right: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-R_sphere.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d522ea3a883e73df3eb1c1/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d522ec6846076e837136e2/?view_only=b214f40525fe44b5bea3103478d08d0d
       midthickness:
-        left: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-L_midthickness.surf.gii
-        right: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-R_midthickness.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d522e92882bdb2bc3ebd17/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d522ed1e7b820217713433/?view_only=b214f40525fe44b5bea3103478d08d0d
       white:
-        left: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-L_white.surf.gii
-        right: share/Inputs/CIVETNMT/src-CIVETNMT_den-41k_hemi-R_white.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d522eda52f9bb3897129b8/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d522ec4f3931c54c90480e/?view_only=b214f40525fe44b5bea3103478d08d0d

--- a/src/neuromaps_prime/resources/nodes/macaque/D99.yaml
+++ b/src/neuromaps_prime/resources/nodes/macaque/D99.yaml
@@ -4,17 +4,17 @@ D99:
   surfaces:
     41k:
       midthickness:
-        left: share/Inputs/D99/src-D99_den-41k_hemi-L_midthickness.surf.gii
-        right: share/Inputs/D99/src-D99_den-41k_hemi-R_midthickness.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5230323e17e1124712b0a/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52303aa1f78e197903529/?view_only=b214f40525fe44b5bea3103478d08d0d
       pial:
-        left: share/Inputs/D99/src-D99_den-41k_hemi-L_pial.surf.gii
-        right: share/Inputs/D99/src-D99_den-41k_hemi-R_pial.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52300ab76e18c739044be/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52302c807054314902927/?view_only=b214f40525fe44b5bea3103478d08d0d
       sphere:
-        left: share/Inputs/D99/src-D99_den-41k_hemi-L_sphere.surf.gii
-        right: share/Inputs/D99/src-D99_den-41k_hemi-R_sphere.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52303743de820043ead18/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52303cd1f7a1773903ffc/?view_only=b214f40525fe44b5bea3103478d08d0d
       white:
-        left: share/Inputs/D99/src-D99_den-41k_hemi-L_white.surf.gii
-        right: share/Inputs/D99/src-D99_den-41k_hemi-R_white.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52303cc9143f354902958/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523022882bdb2bc3ebdee/?view_only=b214f40525fe44b5bea3103478d08d0d
   volumes:
     250um:
-      T1w: share/Inputs/D99/src-D99_res-0p25mm_T1w.nii
+      T1w: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52302a52f9bb3897129cf/?view_only=b214f40525fe44b5bea3103478d08d0d

--- a/src/neuromaps_prime/resources/nodes/macaque/MEBRAINS.yaml
+++ b/src/neuromaps_prime/resources/nodes/macaque/MEBRAINS.yaml
@@ -4,27 +4,21 @@ MEBRAINS:
   surfaces:
     101k:
       sphere:
-        left: share/Inputs/MEBRAINS/src-MEBRAINS_den-101k_hemi-L_sphere.surf.gii
-        right: share/Inputs/MEBRAINS/src-MEBRAINS_den-101k_hemi-R_sphere.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5237d6846076e8371377c/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5237faa1f78e1979035a0/?view_only=b214f40525fe44b5bea3103478d08d0d
       pial:
-        left: share/Inputs/MEBRAINS/src-MEBRAINS_den-101k_hemi-L_pial.surf.gii
-        right: share/Inputs/MEBRAINS/src-MEBRAINS_den-101k_hemi-R_pial.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5237f2882bdb2bc3ebe57/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5237fab76e18c73904530/?view_only=b214f40525fe44b5bea3103478d08d0d
       midthickness:
-        left: share/Inputs/MEBRAINS/src-MEBRAINS_den-101k_hemi-L_midthickness.surf.gii
-        right: share/Inputs/MEBRAINS/src-MEBRAINS_den-101k_hemi-R_midthickness.surf.gii
-      white:
-        left: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-L_white.rsl.gii
-        right: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-R_white.rsl.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5237fe06110211c3ead50/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5237fcc9143f354902a02/?view_only=b214f40525fe44b5bea3103478d08d0d
       inflated:
-        left: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-L_inflated.rsl.gii
-        right: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-R_inflated.rsl.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52388cc9143f354902a1b/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5237e8a846359933ec571/?view_only=b214f40525fe44b5bea3103478d08d0d
       annotation:
-          BM:
-            left: resources/MEBRAINS/annotations/brain_masks/src-MEBRAINS_den-101k_hemi-L_desc-BM_annot.func.gii
-            right: resources/MEBRAINS/annotations/brain_masks/src-MEBRAINS_den-101k_hemi-R_desc-BM_annot.func.gii
-          SD:
-            left: resources/MEBRAINS/annotations/sulcal_depth/src-MEBRAINS_hemi-L_desc-SD_annot.sulc
-            right: resources/MEBRAINS/annotations/sulcal_depth/src-MEBRAINS_hemi-R_desc-SD_annot.sulc
+        BM:
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f51ac406d0c8a912c30ff/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f51ab4572881301679a5b/?view_only=b214f40525fe44b5bea3103478d08d0d
   volumes:
     400um:
-      T1w: share/Inputs/MEBRAINS/src-MEBRAINS_res-0p40mm_T1w.nii
+      T1w: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523814d366de13d713ff6/?view_only=b214f40525fe44b5bea3103478d08d0d

--- a/src/neuromaps_prime/resources/nodes/macaque/NMT2Sym.yaml
+++ b/src/neuromaps_prime/resources/nodes/macaque/NMT2Sym.yaml
@@ -4,17 +4,17 @@ NMT2Sym:
   surfaces:
     41k:
       sphere:
-        left: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-L_sphere.rsl.gii
-        right: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-R_sphere.rsl.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523df23e17e1124712cc2/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523dfcc9143f354902a8a/?view_only=b214f40525fe44b5bea3103478d08d0d
       midthickness:
-        left: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-L_midthickness.rsl.gii
-        right: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-R_midthickness.rsl.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523dd4d366de13d71403f/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523dd6846076e837137e8/?view_only=b214f40525fe44b5bea3103478d08d0d
       white:
-        left: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-L_white.rsl.gii
-        right: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-R_white.rsl.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523dfa52f9bb389712be0/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523dfa52f9bb389712bdf/?view_only=b214f40525fe44b5bea3103478d08d0d
       inflated:
-        left: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-L_inflated.rsl.gii
-        right: share/Inputs/NMT2Sym/src-NMT2Sym_den-41k_hemi-R_inflated.rsl.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523dfab76e18c73904626/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523df4d366de13d714041/?view_only=b214f40525fe44b5bea3103478d08d0d
   volumes:
     250um:
-      T1w: share/Inputs/NMT2Sym/src-NMT2Sym_res-0p25mm_T1w.nii
+      T1w: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523de8a846359933ec5a5/?view_only=b214f40525fe44b5bea3103478d08d0d

--- a/src/neuromaps_prime/resources/nodes/macaque/Yerkes19.yaml
+++ b/src/neuromaps_prime/resources/nodes/macaque/Yerkes19.yaml
@@ -4,181 +4,180 @@ Yerkes19:
   surfaces:
     10k:
       sphere:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_sphere.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-R_sphere.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226e4d366de13d713f48/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226aab76e18c73904448/?view_only=b214f40525fe44b5bea3103478d08d0d
       midthickness:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_midthickness.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-R_midthickness.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226a4f3931c54c9047d7/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226ba52f9bb38971293a/?view_only=b214f40525fe44b5bea3103478d08d0d
       white:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_white.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-R_white.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226ca52f9bb38971293c/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226f49b4c2d6503ecb33/?view_only=b214f40525fe44b5bea3103478d08d0d
       pial:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_pial.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-R_pial.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226e1e7b820217713409/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226b49b4c2d6503ecb22/?view_only=b214f40525fe44b5bea3103478d08d0d
       inflated:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-L_inflated.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-10k_hemi-R_inflated.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d522691e7b820217713402/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226d23e17e11247129bc/?view_only=b214f40525fe44b5bea3103478d08d0d
       annotation:
         PC_Yeo7Networks:
-          left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.label.gii
-          right: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-Yeo7Networks_desc-PC_annot.label.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52a64572881301679aba/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52a37a752a710f2c2b40/?view_only=b214f40525fe44b5bea3103478d08d0di
           notes:
-            - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 10k surface density.
-            - left lookup file -> resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.txt
-            - right lookup file -> resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-Yeo7Networks_desc-PC_annot.txt
+          - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 10k surface density.
+          - 'left lookup file: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52a680941e7c8fa7ad49/?view_only=b214f40525fe44b5bea3103478d08d0d'
+          - 'right lookup file: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52a34572881301679ab8/?view_only=b214f40525fe44b5bea3103478d08d0d'
         PC_MarkovMonkey:
-            left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-L_atlas-MarkovMonkey_desc-PC_annot.label.gii
-            right: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-10k_hemi-R_atlas-MarkovMonkey_desc-PC_annot.label.gii
-            notes:
-              - Markov monkey cortical parcellation, 10k surface density.
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52a37da771710ca7abbd/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52a580941e7c8fa7ad47/?view_only=b214f40525fe44b5bea3103478d08d0di
+          notes:
+          - Markov monkey cortical parcellation, 10k surface density.
     32k:
       sphere:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_sphere.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-R_sphere.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f54791541aee377a7b0c8/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226aab76e18c73904446/?view_only=b214f40525fe44b5bea3103478d08d0d
       midthickness:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_midthickness.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-R_midthickness.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226ea52f9bb389712940/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226aaa1f78e1979033b0/?view_only=b214f40525fe44b5bea3103478d08d0d
       white:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_white.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-R_white.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226d743de820043eac3b/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226b6846076e8371364a/?view_only=b214f40525fe44b5bea3103478d08d0d
       pial:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_pial.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-R_pial.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226be06110211c3eac62/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226ecd1f7a1773903f7a/?view_only=b214f40525fe44b5bea3103478d08d0d
       inflated:
-        left: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-L_inflated.surf.gii
-        right: share/Inputs/Yerkes19/src-Yerkes19_den-32k_hemi-R_inflated.surf.gii
+        left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226e3a883e73df3eb152/?view_only=b214f40525fe44b5bea3103478d08d0d
+        right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226b2882bdb2bc3ebcbd/?view_only=b214f40525fe44b5bea3103478d08d0d
       annotation:
         RM_auto_ampa:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-ampa_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bc270229e9b9679cd4/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - AMPA receptor density, radioligand [³H]AMPA. Ionotropic glutamate receptor.
         RM_auto_cgp5:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-cgp5_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bc80941e7c8fa7ad63/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes:
             - GABA_B receptor density, radioligand [³H]CGP54626. Metabotropic inhibitory GABA receptor.
         RM_auto_damp:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-damp_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52be7a752a710f2c2b4e/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - M3 muscarinic receptor density, radioligand [³H]4-DAMP. Cholinergic receptor.
         RM_auto_dpat:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-dpat_desc-RM_annot.func.gii
-          references: 
-            - https://doi.org/10.1007/s00429-021-02437-y
-            - https://doi.org/10.1038/s41593-023-01351-2
-          notes: 
-            - 5-HT1A receptor density, radioligand [³H]8-OH-DPAT (dpat). Serotonin receptor.
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bd3625c9e6dc679aba/?view_only=b214f40525fe44b5bea3103478d08d0d
+          references:
+          - https://doi.org/10.1007/s00429-021-02437-y
+          - https://doi.org/10.1038/s41593-023-01351-2
+          notes:
+          - 5-HT1A receptor density, radioligand [³H]8-OH-DPAT (dpat). Serotonin receptor.
         RM_auto_dpmg:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-dpmg_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bd4572881301679ac1/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - D1 dopamine receptor density, radioligand [³H]SCH23390. Dopamine receptor.
         RM_auto_flum:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-flum_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bc406d0c8a912c31b9/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - GABA_A/BZ receptor density, radioligand [³H]flumazenil. Benzodiazepine site of GABA_A receptor.
         RM_auto_kain:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-kain_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bdcd87cca253679b64/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - Kainate receptor density, radioligand [³H]kainate. Ionotropic glutamate receptor.
         RM_auto_keta:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-keta_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bc1541aee377a7af41/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - 5-HT2A receptor density, radioligand [³H]ketanserin. Serotonin receptor.
         RM_auto_mk80:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-mk80_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bdd0d28dc642a7aff8/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - NMDA receptor density, radioligand [³H]MK-801. Ionotropic glutamate receptor.
         RM_auto_musc:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-musc_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bd1541aee377a7af43/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - GABA_A receptor density, radioligand [³H]muscimol. Ionotropic inhibitory GABA receptor.
         RM_auto_oxot:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-oxot_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bdcd87cca253679b68/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - M2 muscarinic receptor density, radioligand [³H]oxotremorine-M. Cholinergic receptor.
         RM_auto_pire:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-pire_desc-RM_annot.func.gii
-          references: 
-            - https://doi.org/10.1007/s00429-021-02437-y
-            - https://doi.org/10.1038/s41593-023-01351-2
-          notes: 
-            - M1 muscarinic receptor density, radioligand [³H]pirenzepine. Cholinergic receptor.
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52be406d0c8a912c31be/?view_only=b214f40525fe44b5bea3103478d08d0d
+          references:
+          - https://doi.org/10.1007/s00429-021-02437-y
+          - https://doi.org/10.1038/s41593-023-01351-2
+          notes:
+          - M1 muscarinic receptor density, radioligand [³H]pirenzepine. Cholinergic receptor.
         RM_auto_praz:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-praz_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bd80941e7c8fa7ad68/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - α1-adrenergic receptor density, radioligand [³H]prazosin. Noradrenergic receptor.
         RM_auto_uk14:
-          left: resources/Yerkes19/annotations/receptor_maps/src-Yerkes19_den-32k_hemi-L_acq-auto_trc-uk14_desc-RM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52bc3625c9e6dc679ab7/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1007/s00429-021-02437-y
             - https://doi.org/10.1038/s41593-023-01351-2
           notes: 
             - α2-adrenergic receptor density, radioligand [³H]UK-14304. Noradrenergic receptor.
         MM:
-          left: resources/Yerkes19/annotations/myelin_maps/src-Yerkes19_den-32k_hemi-L_desc-MM_annot.func.gii
-          right: resources/Yerkes19/annotations/myelin_maps/src-Yerkes19_den-32k_hemi-R_desc-MM_annot.func.gii
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52947a752a710f2c2b26/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1073/pnas.1721653115
           notes:
             - Myelin map (bias corrected). MacaqueYerkes19 v1.2.
         SMM:
-          left: resources/Yerkes19/annotations/smoothed_myelin_maps/src-Yerkes19_den-32k_hemi-L_desc-SMM_annot.func.gii
-          right: resources/Yerkes19/annotations/smoothed_myelin_maps/src-Yerkes19_den-32k_hemi-R_desc-SMM_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f527acd87cca253679b05/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f527b80941e7c8fa7ad2d/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1073/pnas.1721653115
           notes:
             - Smoothed myelin map (bias corrected). MacaqueYerkes19 v1.2.
         CT:
-          left: resources/Yerkes19/annotations/cortical_thickness/src-Yerkes19_den-32k_hemi-L_desc-CT_annot.func.gii
-          right: resources/Yerkes19/annotations/cortical_thickness/src-Yerkes19_den-32k_hemi-R_desc-CT_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52d0d8bf292baf2c2d69/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52d07a752a710f2c2b5d/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1073/pnas.1721653115
           notes:
             - Cortical thickness. MacaqueYerkes19 v1.2.
         CV:
-          left: resources/Yerkes19/annotations/curvature/src-Yerkes19_den-32k_hemi-L_desc-CV_annot.func.gii
-          right: resources/Yerkes19/annotations/curvature/src-Yerkes19_den-32k_hemi-R_desc-CV_annot.func.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52877a752a710f2c2b1c/?view_only=b214f40525fe44b5bea3103478d08d0d
+          right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52881541aee377a7af33/?view_only=b214f40525fe44b5bea3103478d08d0d
           references:
             - https://doi.org/10.1073/pnas.1721653115
           notes:
             - Curvature. MacaqueYerkes19 v1.2.
         PC_Yeo7Networks:
-          left: resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-32k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.label.gii
+          left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52a77da771710ca7abc0/?view_only=b214f40525fe44b5bea3103478d08d0d
           notes:
-            - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 32k surface density.
-            - left lookup file -> resources/Yerkes19/annotations/parcellations/src-Yerkes19_den-32k_hemi-L_atlas-Yeo7Networks_desc-PC_annot.txt
+          - Yeo2011 7 Network parcellation (N=1000). Human-to-monkey. 32k surface density.
+          - 'left lookup file: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/6a0f52a3d0d28dc642a7afe5/?view_only=b214f40525fe44b5bea3103478d08d0d'
   volumes:
     500um:
-      T1w: share/Inputs/Yerkes19/src-Yerkes19_res-0p50mm_T1w.nii
+      T1w: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d5226eab76e18c7390444c/?view_only=b214f40525fe44b5bea3103478d08d0d


### PR DESCRIPTION
## This PR:
Adds remote URIs for atlases, transforms, and some annotations (of the ones currently noted in the existing graph). Additional annotations can be added later on.

## Type of Change
- [ ] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [x] Other

## Related Issue(s)
- Replaces #147 by @tamsinrogers 