### PR TITLE
Update dependabot config to update uv

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@
 
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: uv
   directory: /
   schedule:
     interval: monthly


### PR DESCRIPTION
## This PR:
Update dependabot configuration such that it also updates the `uv.lock`

## Type of Change
- [ ] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [x] Other

## Related Issue(s)
n/a