### PR TITLE
fix plotting bug for surface and volume subgraphs

### DIFF
--- a/src/neuromaps_prime/plotting.py
+++ b/src/neuromaps_prime/plotting.py
@@ -264,12 +264,17 @@ def _plot_single_graph(
     save_path: Path | None,
     layout: str,
     colormap: str,
+    legend_rect: tuple[float, float, float, float],
+    legend_loc: str,
+    k: float,
+    iterations: int,
+    seed: int,
 ) -> None:
     """Plot either surface or volume transforms in a single plot."""
     _, ax = plt.subplots(1, 1, figsize=figsize)
 
     # Use optimized layout
-    pos = _get_optimized_layout(graph, layout)
+    pos = _get_optimized_layout(graph, layout, k, iterations, seed)
 
     # Get node colors by species
     node_colors, species_colors_map = _get_node_colors(graph, colormap)
@@ -325,7 +330,7 @@ def _plot_single_graph(
         for attr, color in edge_colors.items()
     ]
 
-    ax.legend(handles=legend_elements, fontsize=font_size, loc="upper right")
+    ax.legend(handles=legend_elements, fontsize=font_size, loc=legend_loc)
     plt.tight_layout()
 
     _save_or_show(save_path)

--- a/src/neuromaps_prime/plotting.py
+++ b/src/neuromaps_prime/plotting.py
@@ -331,7 +331,7 @@ def _plot_single_graph(
     ]
 
     ax.legend(handles=legend_elements, fontsize=font_size, loc=legend_loc)
-    plt.tight_layout()
+    plt.tight_layout(rect=legend_rect)
 
     _save_or_show(save_path)
 


### PR DESCRIPTION
## This PR:
Fixes a bug in `plotting.py` where `_plot_single_graph` was missing parameters passed from `plot_graph`, causing an error when plotting single surface or volume subgraphs.

```
TypeError: _plot_single_graph() got an unexpected keyword argument 'legend_rect'
```

## Type of Change
- [X] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other