### PR TITLE
Add missing mapping method in surface-to-volume transform

### DIFF
--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -258,20 +258,39 @@ class SurfaceTransformOps(BaseModel):
         )
         if target_surface is None:
             raise FileNotFoundError("Unable to find target surface.")
+        
+        ribbon = {
+            surf_type: self.cache.require_surface_atlas(
+                space=target_space,
+                density=target_density,
+                hemisphere=hemisphere,
+                resource_type=surf_type,
+            ).fetch()
+            for surf_type in ("white", "pial")
+        }
+    
         match transformer_type:
             case "label":
+                ribbon_surfs = workbench.label_to_volume_mapping_ribbon_constrained(
+                    inner_surf=ribbon["white"], outer_surf=ribbon["pial"]
+                )
                 return workbench.label_to_volume_mapping(
                     label=out_surface,
                     surface=target_surface.file_path,
                     volume_space=ref_volume,
                     volume_out=output_file_path,
+                    ribbon_constrained=ribbon_surfs,
                 ).volume_out
             case "metric":
+                ribbon_surfs = workbench.metric_to_volume_mapping_ribbon_constrained(
+                    inner_surf=ribbon["white"], outer_surf=ribbon["pial"]
+                )
                 return workbench.metric_to_volume_mapping(
                     metric=out_surface,
                     surface=target_surface.file_path,
                     volume_space=ref_volume,
                     volume_out=output_file_path,
+                    ribbon_constrained=ribbon_surfs,
                 ).volume_out
 
     # ------------------------------------------------------------------ #

--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -258,7 +258,7 @@ class SurfaceTransformOps(BaseModel):
         )
         if target_surface is None:
             raise FileNotFoundError("Unable to find target surface.")
-        
+
         ribbon = {
             surf_type: self.cache.require_surface_atlas(
                 space=target_space,
@@ -268,7 +268,7 @@ class SurfaceTransformOps(BaseModel):
             ).fetch()
             for surf_type in ("white", "pial")
         }
-    
+
         match transformer_type:
             case "label":
                 ribbon_surfs = workbench.label_to_volume_mapping_ribbon_constrained(


### PR DESCRIPTION
## This PR:
`transform_surface_to_volume` was calling `wb_command -metric-to-volume-mapping` and `-label-to-volume-mapping` without specifying a mapping method, causing `ERROR: no mapping method specified`.

Fix uses ribbon-constrained mapping with white/pial surfaces, consistent with the existing pattern in `_project_volume_to_surface` in `volume.py`.

## Type of Change
- [X] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)