### PR TITLE
Fix volume transform atlas lookup & file extension bug

### DIFF
--- a/src/neuromaps_prime/graph/builder.py
+++ b/src/neuromaps_prime/graph/builder.py
@@ -398,7 +398,7 @@ class GraphBuilder(BaseModel):
                 for vol_type, vol_value in types.items():
                     if vol_type == "annotation":
                         for annot_key, annot_dict in vol_value.items():
-                            name = f"{prefix}_{res}_{annot_key}.nii.gz"
+                            name = f"{prefix}_{res}_{annot_key}"
                             annotations.append(
                                 VolumeAnnotation(
                                     name=name,
@@ -406,7 +406,7 @@ class GraphBuilder(BaseModel):
                                     label=annot_key,
                                     resolution=res,
                                     uri=annot_dict.get("uri"),
-                                    file_path=self.data_dir / name,
+                                    file_path=self.data_dir / f"{name}.nii.gz",
                                     references=annot_dict.get("references"),
                                     notes=annot_dict.get("notes"),
                                 )
@@ -419,7 +419,7 @@ class GraphBuilder(BaseModel):
                         cls(
                             name=name,
                             uri=vol_value,
-                            file_path=self.data_dir / name,
+                            file_path=self.data_dir / f"{name}.nii.gz",
                             resolution=res,
                             resource_type=vol_type,
                             references=transform_refs,

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -640,7 +640,8 @@ class NeuromapsGraph(nx.MultiDiGraph):
             output_file_path: Path for the warped output volume.
             interp: Interpolation method.
             interp_params: Optional interpolation parameters.
-            atlas_resource_type: Volume resource type for the reference atlas lookup (default ``'T1w'``).
+            atlas_resource_type: Volume resource type for the reference atlas lookup
+                (default ``'T1w'``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -636,12 +636,12 @@ class NeuromapsGraph(nx.MultiDiGraph):
             source_space: Source brain template space.
             target_space: Target brain template space.
             resolution: Target volume resolution (e.g. ``'2mm'``).
-            resource_type: Volume resource type (e.g. ``'composite'``).
+            resource_type: Volume transform resource type (e.g. ``'composite'``).
             output_file_path: Path for the warped output volume.
             interp: Interpolation method.
             interp_params: Optional interpolation parameters.
-            atlas_resource_type: Volume resource type for the reference atlas lookup
-                (default ``'T1w'``).
+            atlas_resource_type: Volume resource type for the reference atlas 
+                lookup (default ``'T1w'``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -640,7 +640,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
             output_file_path: Path for the warped output volume.
             interp: Interpolation method.
             interp_params: Optional interpolation parameters.
-            atlas_resource_type: Volume resource type for the reference atlas 
+            atlas_resource_type: Volume resource type for the reference atlas
                 lookup (default ``'T1w'``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -625,6 +625,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         output_file_path: str,
         interp: str = "linear",
         interp_params: dict[str, Any] | None = None,
+        atlas_resource_type: str = "T1w",
         *,
         provider: str | None = None,
     ) -> Path:
@@ -635,10 +636,11 @@ class NeuromapsGraph(nx.MultiDiGraph):
             source_space: Source brain template space.
             target_space: Target brain template space.
             resolution: Target volume resolution (e.g. ``'2mm'``).
-            resource_type: Volume resource type (e.g. ``'T1w'``).
+            resource_type: Volume resource type (e.g. ``'composite'``).
             output_file_path: Path for the warped output volume.
             interp: Interpolation method.
             interp_params: Optional interpolation parameters.
+            atlas_resource_type: Volume resource type for the reference atlas lookup (default ``'T1w'``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 
@@ -654,6 +656,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
             output_file_path=output_file_path,
             interp=interp,
             interp_params=interp_params,
+            atlas_resource_type=atlas_resource_type,
             provider=provider,
         )
 

--- a/src/neuromaps_prime/graph/transforms/volume.py
+++ b/src/neuromaps_prime/graph/transforms/volume.py
@@ -71,12 +71,12 @@ class VolumeTransformOps(BaseModel):
             source_space: Source brain template space name.
             target_space: Target brain template space name.
             resolution: Target volume resolution (e.g. ``'1mm'``, ``'500um'``).
-            resource_type: Volume resource type (e.g. ``'composite'``).
+            resource_type: Volume transform resource type (e.g. ``'composite'``).
             output_file_path: Path for the warped output volume.
             interp: Interpolation method passed to the warp tool.
             interp_params: Optional additional interpolation parameters.
-            atlas_resource_type: Volume resource type for the reference atlas lookup
-                (default ``'T1w'``).
+            atlas_resource_type: Volume resource type for the reference atlas 
+                lookup (default ``'T1w'``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 

--- a/src/neuromaps_prime/graph/transforms/volume.py
+++ b/src/neuromaps_prime/graph/transforms/volume.py
@@ -75,7 +75,8 @@ class VolumeTransformOps(BaseModel):
             output_file_path: Path for the warped output volume.
             interp: Interpolation method passed to the warp tool.
             interp_params: Optional additional interpolation parameters.
-            atlas_resource_type: Volume resource type for the reference atlas lookup (default ``'T1w'``).
+            atlas_resource_type: Volume resource type for the reference atlas lookup
+                (default ``'T1w'``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 

--- a/src/neuromaps_prime/graph/transforms/volume.py
+++ b/src/neuromaps_prime/graph/transforms/volume.py
@@ -60,6 +60,7 @@ class VolumeTransformOps(BaseModel):
         output_file_path: str,
         interp: str = "linear",
         interp_params: dict[str, Any] | None = None,
+        atlas_resource_type: str = "T1w",
         *,
         provider: str | None = None,
     ) -> Path:
@@ -70,10 +71,11 @@ class VolumeTransformOps(BaseModel):
             source_space: Source brain template space name.
             target_space: Target brain template space name.
             resolution: Target volume resolution (e.g. ``'1mm'``, ``'500um'``).
-            resource_type: Volume resource type (e.g. ``'T1w'``, ``'composite'``).
+            resource_type: Volume resource type (e.g. ``'composite'``).
             output_file_path: Path for the warped output volume.
             interp: Interpolation method passed to the warp tool.
             interp_params: Optional additional interpolation parameters.
+            atlas_resource_type: Volume resource type for the reference atlas lookup (default ``'T1w'``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 
@@ -101,12 +103,12 @@ class VolumeTransformOps(BaseModel):
             )
 
         target_atlas = self.cache.get_volume_atlas(
-            space=target_space, resolution=resolution, resource_type=resource_type
+            space=target_space, resolution=resolution, resource_type=atlas_resource_type
         )
         if target_atlas is None:
             raise ValueError(
                 f"No volume atlas found for '{target_space}' "
-                f"(resolution='{resolution}', resource_type='{resource_type}')"
+                f"(resolution='{resolution}', resource_type='{atlas_resource_type}')"
             )
 
         return vol_to_vol(

--- a/src/neuromaps_prime/graph/transforms/volume.py
+++ b/src/neuromaps_prime/graph/transforms/volume.py
@@ -75,7 +75,7 @@ class VolumeTransformOps(BaseModel):
             output_file_path: Path for the warped output volume.
             interp: Interpolation method passed to the warp tool.
             interp_params: Optional additional interpolation parameters.
-            atlas_resource_type: Volume resource type for the reference atlas 
+            atlas_resource_type: Volume resource type for the reference atlas
                 lookup (default ``'T1w'``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.


### PR DESCRIPTION
## This PR:
Fixes for bugs when running volume transforms from running end-to-end. All were found while testing the example volume transform script with Yerkes19 -> MEBRAINS transforms.

 1. Volume atlas lookup fails when transform and atlas have different resource types.`volume_to_volume_transformer` used a single `resource_type` parameter for both the transform lookup and the reference atlas lookup. The MEBRAINS to Yerkes19  transform is registered as `composite` (a warp field) while the Yerkes19 reference  atlas is registered as `T1w`, so no single value worked for both lookups.
 - **Error:** `ValueError: No volume atlas found for 'Yerkes19' (resolution='500um', resource_type='composite')`
  - **Fix:** Added `atlas_resource_type` param that defaults to "T1w" so the transform lookup uses `resource_type`, the atlas lookup uses `atlas_resource_type`. 

2. Volume atlas and transform file paths missing `.nii `extension so ANTs failed when trying to use the ref atlas without extension
- **Error:** `file /styx_input/1/Yerkes19_500um_T1w is not recognized as a supported image format antsApplyTransforms: Segmentation fault`
-  **Fix:** Changed `file_path` construction to `data_dir / f"{name}.nii.gz"` for both volume resources and volume annotations. `name` field kept without extension because it is used to identify the file


## Type of Change
- [X] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)