### PR TITLE
Experimental transformations warning

### DIFF
--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from niwrap import workbench
 from pydantic import BaseModel, PrivateAttr
@@ -25,6 +25,9 @@ from neuromaps_prime.transforms.utils import (
     estimate_surface_density,
     validate_surface_file,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class SurfaceTransformOps(BaseModel):
@@ -603,3 +606,31 @@ class SurfaceTransformOps(BaseModel):
             f"sphere.surf.gii"
         )
         return str(parent / fname)
+
+    def _experimental_warn(
+        self, paths: list[str], spaces: Sequence[Sequence[str]] | None = None
+    ) -> None:
+        """Warn if experimental transforms (spaces) encountered in transform paths.
+
+        Args:
+            paths: Transform paths
+            spaces: Experimental transforms between spaces
+        """
+        if spaces is None:
+            return
+
+        sep = "\x00"
+        sep_paths = sep + sep.join(paths) + sep
+        for space in spaces:
+            fwd = sep + sep.join(space) + sep
+            if fwd in sep_paths:
+                self._logger.warning(
+                    f"Experimental transformation found: {'->'.join(space)}"
+                )
+                continue
+
+            rev = sep + sep.join(reversed(space)) + sep
+            if rev in sep_paths:
+                self._logger.warning(
+                    f"Experimental transformations found: {'->'.join(reversed(space))}",
+                )

--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -30,7 +30,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 # Experimental transformations that should throw a warning; only need to list one way
-EXPERIMENTAL_XFMS = [["NMT2Sym", "MBM"]]
+EXPERIMENTAL_XFMS: list[tuple[list[str], str | None]] = [
+    (["NMT2Sym", "MBM"], "macaque_marmoset")
+]
 
 
 class SurfaceTransformOps(BaseModel):
@@ -56,6 +58,7 @@ class SurfaceTransformOps(BaseModel):
     cache: GraphCache
     utils: GraphUtils
     surface_to_surface_key: str = "surface_to_surface"
+    experimental_xfms: list[tuple[list[str], str | None]] | None = EXPERIMENTAL_XFMS
     _logger: logging.Logger = PrivateAttr()
 
     def model_post_init(self, __context: Any) -> None:  # noqa: ANN401
@@ -342,7 +345,9 @@ class SurfaceTransformOps(BaseModel):
             raise ValueError(f"No valid surface path from '{source}' to '{target}'")
 
         # Throw experimental warnings if following transformations encountered
-        self._experimental_warn(paths=path, spaces=EXPERIMENTAL_XFMS)
+        self._experimental_warn(
+            paths=path, spaces=self.experimental_xfms, provider=provider
+        )
 
         if len(path) == 2:
             return self.cache.get_surface_transform(
@@ -614,30 +619,47 @@ class SurfaceTransformOps(BaseModel):
         return str(parent / fname)
 
     def _experimental_warn(
-        self, paths: list[str], spaces: Sequence[Sequence[str]] | None = None
+        self,
+        paths: list[str],
+        *,
+        spaces: Sequence[tuple[Sequence[str], str | None]] | None = None,
+        provider: str | None = None,
     ) -> None:
-        """Warn if experimental transforms (spaces) encountered in transform paths.
+        """Warn if any experimental transform space matches a transform path.
 
         Args:
-            paths: Transform paths
-            spaces: Experimental transforms between spaces
+            paths: Transform paths to check.
+            spaces: Experimental transform paths paired with an optional
+                provider. A space with provider ``None`` applies to all
+                providers.
+            provider: Provider to filter spaces by. ``None`` skips filtering.
         """
-        if spaces is None:
+        if not spaces:
             return
 
         sep = "\x00"
-        sep_paths = sep + sep.join(paths) + sep
-        for space in spaces:
-            fwd = sep + sep.join(space) + sep
+        sep_paths = f"{sep}{sep.join(paths)}{sep}"
+
+        for space, experimental_provider in spaces:
+            if (
+                provider is not None
+                and experimental_provider is not None
+                and experimental_provider != provider
+            ):
+                continue
+
+            space = tuple(space)
+            fwd = f"{sep}{sep.join(space)}{sep}"
             if fwd in sep_paths:
                 self._logger.warning(
-                    f"Experimental transformation found: {' -> '.join(space)}"
+                    "Experimental transformation found: %s",
+                    " -> ".join(space),
                 )
                 continue
 
-            rev = sep + sep.join(reversed(space)) + sep
+            rev = f"{sep}{sep.join(reversed(space))}{sep}"
             if rev in sep_paths:
                 self._logger.warning(
-                    "Experimental transformations found: "
-                    f"{' -> '.join(reversed(space))}",
+                    "Experimental transformation found: %s",
+                    " -> ".join(reversed(space)),
                 )

--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -29,6 +29,9 @@ from neuromaps_prime.transforms.utils import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+# Experimental transformations that should throw a warning; only need to list one way
+EXPERIMENTAL_XFMS = [["NMT2Sym", "MBM"]]
+
 
 class SurfaceTransformOps(BaseModel):
     """Surface-to-surface transformation operations.
@@ -338,6 +341,9 @@ class SurfaceTransformOps(BaseModel):
         if len(path) < 2:
             raise ValueError(f"No valid surface path from '{source}' to '{target}'")
 
+        # Throw experimental warnings if following transformations encountered
+        self._experimental_warn(paths=path, spaces=EXPERIMENTAL_XFMS)
+
         if len(path) == 2:
             return self.cache.get_surface_transform(
                 source=source,
@@ -625,12 +631,13 @@ class SurfaceTransformOps(BaseModel):
             fwd = sep + sep.join(space) + sep
             if fwd in sep_paths:
                 self._logger.warning(
-                    f"Experimental transformation found: {'->'.join(space)}"
+                    f"Experimental transformation found: {' -> '.join(space)}"
                 )
                 continue
 
             rev = sep + sep.join(reversed(space)) + sep
             if rev in sep_paths:
                 self._logger.warning(
-                    f"Experimental transformations found: {'->'.join(reversed(space))}",
+                    "Experimental transformations found: "
+                    f"{' -> '.join(reversed(space))}",
                 )


### PR DESCRIPTION
## This PR:
Adds an experimental warning for certain transformations. Also includes a `provider` tag to filter for specific transformations to warn for. The assumption is that both a forward and reverse transform would be experimental, so only one needs to be provided. 

## Type of Change
- [ ] Bug fix
- [x] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)
n/a