### PR TITLE
Pin niwrap version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only"
 ]
 dependencies = [
-  "niwrap>=0.9.2",
+  "niwrap>=0.9.2,<1.0",
   "nibabel>=5.2.1",
   "pyyaml>=6.0.2",
   "networkx>=3.6.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1033,7 +1033,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.10.7" },
     { name = "networkx", specifier = ">=3.6.1" },
     { name = "nibabel", specifier = ">=5.2.1" },
-    { name = "niwrap", specifier = ">=0.9.2" },
+    { name = "niwrap", specifier = ">=0.9.2,<1.0" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "platformdirs", specifier = ">=4.10.0" },
     { name = "pydantic", specifier = ">=2.12.3" },


### PR DESCRIPTION
## This PR:
Temporarily pin `niwrap<1.0` until changes are tested. Also resolves installations pre-emptively installing transitive `niwrap_* > 1.0` dependencies.

## Type of Change
- [x] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)
- #[issue number] by @[original issue author]