### PR TITLE
Eigenmode Validation Test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
   "scipy>=1.17.0",
   "styxpodman",
   "requests>=2.34.2",
-  "platformdirs>=4.10.0"
+  "platformdirs>=4.10.0",
+  "neuromodes>=0.1.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dev = [
   "types-requests>=2.33.0.20260518"
 ]
 docs = ["pdoc>=15.0.4"]
-[dependency-groups]
 tests = [
   "pandas>=3.0.3",
   "neuromodes>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "styxpodman",
   "requests>=2.34.2",
   "platformdirs>=4.10.0",
-  "neuromodes>=0.1.0",
 ]
 
 [dependency-groups]
@@ -41,7 +40,11 @@ dev = [
   "types-requests>=2.33.0.20260518"
 ]
 docs = ["pdoc>=15.0.4"]
-tests = ["pandas>=3.0.3"]
+[dependency-groups]
+tests = [
+  "pandas>=3.0.3",
+  "neuromodes>=0.1.0",
+]
 validate = ["check-jsonschema>=0.37.1"]
 
 [build-system]

--- a/tests/regression/test_surf_eigen.py
+++ b/tests/regression/test_surf_eigen.py
@@ -1,0 +1,156 @@
+"""Regression test for cyclic surface transform preservation using eigenmodes.
+
+For each NHP atlas:
+
+1. Compute eigenmode on the original midthickness surface.
+2. Find cycle through the surface transform graph.
+3. Apply each surface transformation in cycle.
+4. Recompute eigenmode on the final returned surface.
+5. Compare the original and cycled eigensystems.
+
+The test evaluates whether the surface transformation cycle preserves eigenmodes.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import networkx as nx
+import numpy as np
+
+from neuromaps_prime.graph import NeuromapsGraph
+from neuromodes.eigen import EigenSolver
+
+logger = logging.getLogger(__name__)
+
+
+NHP_SPACES = [
+    "Yerkes19",
+    "D99",
+    "MEBRAINS",
+    "NMT2Sym",
+    "CIVETNMT",
+]
+
+def get_valid_spaces(
+    graph: NeuromapsGraph,
+) -> list[str]:
+    """Return NHP spaces with required surface resources."""
+
+    valid = []
+
+    for space in NHP_SPACES:
+        try:
+            density = graph.find_highest_density(space)
+
+            graph.fetch_surface_atlas(
+                space=space,
+                density=density,
+                hemisphere="right",
+                resource_type="sphere",
+            )
+
+            graph.fetch_surface_atlas(
+                space=space,
+                density=density,
+                hemisphere="right",
+                resource_type="midthickness",
+            )
+
+            valid.append(space)
+
+        except Exception as exc:
+            logger.warning(
+                "Skipping %s: %s",
+                space,
+                exc,
+            )
+
+    return valid
+
+
+def compute_eigenmodes(
+    surface: Path,
+    *,
+    num_modes: int = 100,
+):
+    """Compute surface eigenmodes using neuromodes."""
+
+    solver = EigenSolver(
+        str(surface),
+    )
+
+    solver.solve(
+        n_modes=num_modes,
+    )
+
+    return (
+        solver.evals,
+        solver.emodes,
+    )
+
+
+def test_surface_eigenmode_preservation(
+    tmp_path: Path,
+):
+    """Validate Yerkes19 eigenmode preservation.
+
+    TODO:
+        Replace the placeholder final eigenmode with the eigenmode
+        calculated after applying the full transform cycle.
+    """
+
+    logging.basicConfig(
+        level=logging.INFO,
+    )
+
+    graph = NeuromapsGraph()
+
+    space = "Yerkes19"
+    hemisphere = "right"
+
+    density = graph.find_highest_density(
+        space,
+    )
+
+    yerkes_surface = Path(
+        graph.fetch_surface_atlas(
+            space=space,
+            density=density,
+            hemisphere=hemisphere,
+            resource_type="midthickness",
+        ).fetch()
+    )
+
+    logger.info(
+        "Computing Yerkes19 eigenmodes",
+    )
+
+    eigvals_original, eigvecs_original = compute_eigenmodes(
+        yerkes_surface,
+        num_modes=100,
+    )
+
+    # placeholder, this will become the eigenmode computed after the transform cycle.
+    logger.info(
+        "Compare initial Yerkes19 eigenmode to final Yerkes19 eigenmode",
+    )
+
+    eigvals_final = eigvals_original    # scalar values associated with each eigenmode
+    eigvecs_final = eigvecs_original    # actual spatial patterns on the surface
+
+    # check that the eigenmode results are numerically the same
+    assert np.allclose(
+        eigvals_original,
+        eigvals_final,
+    )
+    assert np.allclose(
+        eigvecs_original,
+        eigvecs_final,
+    )
+
+    logger.info(
+        "Yerkes19 eigenmode preserved",
+    )

--- a/tests/regression/test_surf_eigen.py
+++ b/tests/regression/test_surf_eigen.py
@@ -34,6 +34,7 @@ NHP_SPACES = [
     "CIVETNMT",
 ]
 
+
 def get_valid_spaces(
     graph: NeuromapsGraph,
 ) -> list[str]:
@@ -138,8 +139,8 @@ def test_surface_eigenmode_preservation(
         "Compare initial Yerkes19 eigenmode to final Yerkes19 eigenmode",
     )
 
-    eigvals_final = eigvals_original    # scalar values associated with each eigenmode
-    eigvecs_final = eigvecs_original    # actual spatial patterns on the surface
+    eigvals_final = eigvals_original  # scalar values associated with each eigenmode
+    eigvecs_final = eigvecs_original  # actual spatial patterns on the surface
 
     # check that the eigenmode results are numerically the same
     assert np.allclose(

--- a/tests/regression/test_surf_eigen.py
+++ b/tests/regression/test_surf_eigen.py
@@ -14,14 +14,15 @@ The test evaluates whether the surface transformation cycle preserves eigenmodes
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import networkx as nx
 import numpy as np
 
 from neuromaps_prime.graph import NeuromapsGraph
-from neuromodes.eigen import EigenSolver
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,6 @@ def get_valid_spaces(
     graph: NeuromapsGraph,
 ) -> list[str]:
     """Return NHP spaces with required surface resources."""
-
     valid = []
 
     for space in NHP_SPACES:
@@ -76,9 +76,9 @@ def compute_eigenmodes(
     surface: Path,
     *,
     num_modes: int = 100,
-):
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Compute surface eigenmodes using neuromodes."""
-
+    from neuromodes.eigen import EigenSolver
     solver = EigenSolver(
         str(surface),
     )
@@ -93,16 +93,13 @@ def compute_eigenmodes(
     )
 
 
-def test_surface_eigenmode_preservation(
-    tmp_path: Path,
-):
+def test_surface_eigenmode_preservation() -> None:
     """Validate Yerkes19 eigenmode preservation.
 
-    TODO:
+    Todo:
         Replace the placeholder final eigenmode with the eigenmode
         calculated after applying the full transform cycle.
     """
-
     logging.basicConfig(
         level=logging.INFO,
     )

--- a/tests/regression/test_surf_eigen.py
+++ b/tests/regression/test_surf_eigen.py
@@ -79,6 +79,7 @@ def compute_eigenmodes(
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Compute surface eigenmodes using neuromodes."""
     from neuromodes.eigen import EigenSolver
+
     solver = EigenSolver(
         str(surface),
     )

--- a/tests/regression/test_surf_matrix.py
+++ b/tests/regression/test_surf_matrix.py
@@ -441,7 +441,7 @@ def test_surface_transform_matrix(tmp_path: Path) -> None:
         color="#0044AA",
         pad=10,
     )
-    plt.xlabel("Absolute igned distance error", labelpad=12)
+    plt.xlabel("Absolute signed distance error", labelpad=12)
     plt.ylabel("Vertex count", labelpad=12)
     fig4_caption = (
         "Figure 4. Distribution of vertex-wise absolute signed-distance errors"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -687,6 +687,22 @@ wheels = [
 ]
 
 [[package]]
+name = "lapy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nibabel" },
+    { name = "numpy" },
+    { name = "plotly" },
+    { name = "psutil" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/95/361169d744172dd4c289bcb1d910c85294e159b3f8caae532f823e93f66e/lapy-1.6.0.tar.gz", hash = "sha256:b29c5a1ded33ff507f01378f4dd70525d13f8b5d3219bb44d2e3ff981bbfaac0", size = 84831, upload-time = "2026-03-16T13:08:05.633Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/7c/f74fe3536f980cebb6c117395e728ecea4711415e51898b373df78441ba0/lapy-1.6.0-py3-none-any.whl", hash = "sha256:94d0c965425abcc110a773fb51822d7a4d7123d27fbd625c0890f34c92148ecf", size = 90568, upload-time = "2026-03-16T13:08:04.319Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -981,6 +997,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/66ed1fc6e38a0c0f330627ec5c5d597990d6159b6712b82af0ad2c65f06c/narwhals-2.23.0.tar.gz", hash = "sha256:13e7ff5b4bb4a2f77b907c2e4d8a76e273dfc1323a3c997440a2f9fd26aed408", size = 656209, upload-time = "2026-07-01T11:21:53.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/4e/afc8c31605cb8be1d3bb4438c4d979daa104dab6306cd2b87abe9c3a7299/narwhals-2.23.0-py3-none-any.whl", hash = "sha256:769e7b9ab102c93d8fa019f6b4cd1a657909b04a20bf6210e5a35aae06814ae9", size = 458938, upload-time = "2026-07-01T11:21:51.677Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -995,6 +1020,7 @@ source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },
     { name = "networkx" },
+    { name = "neuromodes" },
     { name = "nibabel" },
     { name = "niwrap" },
     { name = "numpy" },
@@ -1032,6 +1058,7 @@ validate = [
 requires-dist = [
     { name = "matplotlib", specifier = ">=3.10.7" },
     { name = "networkx", specifier = ">=3.6.1" },
+    { name = "neuromodes", specifier = ">=0.1.0" },
     { name = "nibabel", specifier = ">=5.2.1" },
     { name = "niwrap", specifier = ">=0.9.2,<1.0" },
     { name = "numpy", specifier = ">=2.4.6" },
@@ -1058,6 +1085,21 @@ dev = [
 docs = [{ name = "pdoc", specifier = ">=15.0.4" }]
 tests = [{ name = "pandas", specifier = ">=3.0.3" }]
 validate = [{ name = "check-jsonschema", specifier = ">=0.37.1" }]
+
+[[package]]
+name = "neuromodes"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lapy" },
+    { name = "nibabel" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/807146ef48d2e9d0fde4dfea6c0364ddbdbac16e6b31571a98f63025b3c1/neuromodes-0.1.0.tar.gz", hash = "sha256:bc49cf3d22cc5d8247471826aa0638f6986f0cfb1343da70277c85bf15ed7c4b", size = 4820465, upload-time = "2026-06-13T07:54:46.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/96/0000a58db37d892c5ceffef444ffb265c35595ce670a0084f2c165c14a7d/neuromodes-0.1.0-py3-none-any.whl", hash = "sha256:cfc48c74a1094fff1f32d6fedfc0d88c54108843bb6ee19a0e1f82fd703d4fb0", size = 4804564, upload-time = "2026-06-13T07:54:40.533Z" },
+]
 
 [[package]]
 name = "nibabel"
@@ -1522,6 +1564,19 @@ wheels = [
 ]
 
 [[package]]
+name = "plotly"
+version = "6.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/fd/d72c292d78aadb93d1a9bcd76bf3c678271040c7cf10abe5788b33040a39/plotly-6.8.0.tar.gz", hash = "sha256:e088e7ddc68d4f70e3d66659224727a45296d71d2b8284181862d3d8f1f0d88f", size = 6915161, upload-time = "2026-06-03T18:33:40.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/14/abe5ce876ab5b66ee3c691bf537fcd43d037aea55d447aacf74630a8f31e/plotly-6.8.0-py3-none-any.whl", hash = "sha256:13c5c4a0f70b74cab1913eda0de49b826df5931708eb6f9c3010040614700ec8", size = 9902055, upload-time = "2026-06-03T18:33:34.26Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1544,6 +1599,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## This PR:
Regression test for cyclic surface transform preservation using eigenmodes.

For each NHP atlas:

1. Compute eigenmode on the original midthickness surface.
2. Find cycle through the surface transform graph.
3. Apply each surface transformation in cycle.
4. Recompute eigenmode on the final returned surface.
5. Compare the original and cycled eigensystems.

⚠️ currently just asserts that `initial Yerkes19 eigenmode` == `final Yerkes19 eigenmode`
🔜 implement NetworkX cycle and compare `initial Yerkes19 eigenmode` to `final transformed Yerkes19 eigenmode`

## Type of Change
- [x] Enhancement

```
(base) CMI-RSCH-MBP118:examples tamsin.rogers$ uv run pytest /Users/tamsin.rogers/Desktop/github/neuromaps-prime/tests/regression/test_surf_eigen.py -v -x -s -o log_cli=true -o log_cli_level=DEBUG
============================================= test session starts =============================================
platform darwin -- Python 3.12.2, pytest-9.1.1, pluggy-1.6.0 -- /Users/tamsin.rogers/Desktop/github/neuromaps-prime/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/tamsin.rogers/Desktop/github/neuromaps-prime
configfile: pyproject.toml
plugins: cov-7.1.0
collected 1 item                                                                                              

../tests/regression/test_surf_eigen.py::test_surface_eigenmode_preservation 
------------------------------------------------ live log call ------------------------------------------------
INFO     test_surf_eigen:test_surf_eigen.py:126 Computing Yerkes19 eigenmodes
DEBUG    lapy._tria_io:_tria_io.py:539 --> GIFTI format       ... 
INFO     lapy._tria_io:_tria_io.py:571  --> DONE ( V: 32492 , T: 64980 )
INFO     lapy.solver:solver.py:759 Solver: spsolve (LU decomposition) ...
INFO     test_surf_eigen:test_surf_eigen.py:136 Compare initial Yerkes19 eigenmode to final Yerkes19 eigenmode
INFO     test_surf_eigen:test_surf_eigen.py:153 Yerkes19 eigenmode preserved
PASSED

============================================== 1 passed in 3.35s ==============================================
(base) CMI-RSCH-MBP118:examples tamsin.rogers$ 
```