### PR TITLE
feat: Add handling for remote GitHub stored files 

### DIFF
--- a/src/neuromaps_prime/fetcher.py
+++ b/src/neuromaps_prime/fetcher.py
@@ -6,7 +6,11 @@ from urllib.parse import urlparse
 from neuromaps_prime import remote
 
 _STORAGES = {"osf": remote.OSFStorage(), "github": remote.GitHubStorage()}
-_HOST_MAP = {"osf.io": _STORAGES["osf"], "github.com": _STORAGES["github"]}
+_HOST_MAP = {
+    "osf.io": _STORAGES["osf"],
+    "github.com": _STORAGES["github"],
+    "raw.githubusercontent.com": _STORAGES["github"],
+}
 
 
 def id_storage(uri: str) -> str | None:

--- a/src/neuromaps_prime/fetcher.py
+++ b/src/neuromaps_prime/fetcher.py
@@ -1,30 +1,30 @@
 """Helpers for grabbing from remote repositories."""
 
 from pathlib import Path
-from typing import Literal
 from urllib.parse import urlparse
 
-from neuromaps_prime.remote import OSFStorage
+from neuromaps_prime import remote
+
+_STORAGES = {"osf": remote.OSFStorage(), "github": remote.GitHubStorage()}
+_HOST_MAP = {"osf.io": _STORAGES["osf"], "github.com": _STORAGES["github"]}
 
 
-def id_storage(uri: str) -> Literal["osf"] | None:
+def id_storage(uri: str) -> str | None:
     """Identify the storage type.
 
     Args:
         uri: Remote URI to fetch data from
 
     Returns:
-        String indicating type of storage (one of 'osf')
+        String indicating type of storage (one of 'osf', 'github')
     """
-
-    def _find_host(storage: str, host: str) -> bool:
-        return storage == host or host.endswith(storage)
-
     host = urlparse(uri).hostname
-    if host is not None:
-        host = host.lower()
-        if _find_host(storage="osf.io", host=host):
-            return "osf"
+    if host is None:
+        return None
+    host = host.lower()
+    for k, v in _HOST_MAP.items():
+        if host == k or host.endswith(k):
+            return next(name for name, s in _STORAGES.items() if s is v)
     return None
 
 
@@ -34,13 +34,18 @@ def download_and_validate(uri: str, dest: str | Path) -> None:
     Args:
         uri: Remote URI to fetch data from
         dest: Output file path name
-        token: Optional token to use for remote storage
 
     Raises:
         ValueError: if storage cannot be identified from provided URI
     """
-    match id_storage(uri):
-        case "osf":
-            OSFStorage().download(uri, Path(dest))
-        case _:
-            raise ValueError(f"Could not identify storage from uri: {uri}")
+    host = urlparse(uri).hostname
+    storage = None
+    if host is not None:
+        host = host.lower()
+        storage = next(
+            (v for k, v in _HOST_MAP.items() if host == k or host.endswith(k)), None
+        )
+
+    if storage is None:
+        raise ValueError(f"Could not identify storage from uri: {uri}")
+    storage.download(uri, Path(dest))  # type: ignore[attr-defined]

--- a/src/neuromaps_prime/remote/__init__.py
+++ b/src/neuromaps_prime/remote/__init__.py
@@ -1,5 +1,6 @@
 """Module associated with remote storages."""
 
+from .github import GitHubStorage
 from .osf import OSFStorage
 
-__all__ = ["OSFStorage"]
+__all__ = ["GitHubStorage", "OSFStorage"]

--- a/src/neuromaps_prime/remote/github.py
+++ b/src/neuromaps_prime/remote/github.py
@@ -20,23 +20,25 @@ class GitHubFileMeta(BaseModel):
 _BLOB_RE = re.compile(
     r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/blob/(?P<ref>[^/]+)/(?P<path>.+)"
 )
+_RAW_RE = re.compile(
+    r"raw\.githubusercontent\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/"
+    r"(?:refs/(?:tags|heads)/)?(?P<ref>[^/]+)/(?P<path>.+)"
+)
 
 
 class GitHubStorage(BaseModel):
     """Fetch file from public GitHub repo.
 
-    Blob URL provided would be similar to:
-
-    https://github.com/{owner}/{repo}/blob/{ref}/{path}
+    Handles both blob and raw urls.
     """
 
     chunk_size: int = 8192
 
     @staticmethod
     def _parse(url: str) -> tuple[str, str, str, str]:
-        m = _BLOB_RE.search(url)
+        m = _BLOB_RE.search(url) or _RAW_RE.search(url)
         if not m:
-            raise ValueError(f"Unrecognized GitHub blob URL: {url}")
+            raise ValueError(f"Unrecognized GitHub URL: {url}")
         return m["owner"], m["repo"], m["ref"], m["path"]
 
     def get_meta(self, url: str) -> GitHubFileMeta:

--- a/src/neuromaps_prime/remote/github.py
+++ b/src/neuromaps_prime/remote/github.py
@@ -1,0 +1,67 @@
+"""Model for fetching from GitHub repos (tag/branch/commit)."""
+
+import hashlib
+import re
+from pathlib import Path
+
+import requests
+from pydantic import BaseModel
+
+
+class GitHubFileMeta(BaseModel):
+    """File metadata from GitHub contents API."""
+
+    name: str
+    size: int
+    sha: str
+    download_url: str
+
+
+_BLOB_RE = re.compile(
+    r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/blob/(?P<ref>[^/]+)/(?P<path>.+)"
+)
+
+
+class GitHubStorage(BaseModel):
+    """Fetch file from public GitHub repo.
+
+    Blob URL provided would be similar to:
+
+    https://github.com/{owner}/{repo}/blob/{ref}/{path}
+    """
+
+    chunk_size: int = 8192
+
+    @staticmethod
+    def _parse(url: str) -> tuple[str, str, str, str]:
+        m = _BLOB_RE.search(url)
+        if not m:
+            raise ValueError(f"Unrecognized GitHub blob URL: {url}")
+        return m["owner"], m["repo"], m["ref"], m["path"]
+
+    def get_meta(self, url: str) -> GitHubFileMeta:
+        """Get metadata from remote GitHub file (given blob URL)."""
+        owner, repo, ref, path = self._parse(url)
+        api_url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+        r = requests.get(api_url, params={"ref": ref}, timeout=90)
+        r.raise_for_status()
+        return GitHubFileMeta(**r.json())
+
+    def download(self, url: str, dest: Path) -> None:
+        """Download remote GitHub file (given blob URL)."""
+        meta = self.get_meta(url)
+        r = requests.get(meta.download_url, stream=True, timeout=90)
+        r.raise_for_status()
+
+        content = bytearray()
+        with dest.open("wb") as f:
+            for chunk in r.iter_content(self.chunk_size):
+                f.write(chunk)
+                content.extend(chunk)
+
+        header = f"blob {len(content)}\0".encode()
+        actual = hashlib.sha1(
+            header + bytes(content), usedforsecurity=False
+        ).hexdigest()
+        if actual != meta.sha:
+            raise ValueError(f"Checksum mismatch: {actual} != {meta.sha}")

--- a/tests/unit/remote/test_github.py
+++ b/tests/unit/remote/test_github.py
@@ -1,0 +1,155 @@
+"""Unit tests for GitHub remote storage."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from neuromaps_prime.remote.github import GitHubFileMeta, GitHubStorage
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+MOCK_CONTENT = b"test content"
+MOCK_SHA = hashlib.sha1(
+    f"blob {len(MOCK_CONTENT)}\0".encode() + MOCK_CONTENT, usedforsecurity=False
+).hexdigest()
+
+MOCK_OWNER = "mockowner"
+MOCK_REPO = "mockrepo"
+MOCK_REF = "v0.1"
+MOCK_PATH = "data/test.txt"
+MOCK_URL = f"https://github.com/{MOCK_OWNER}/{MOCK_REPO}/blob/{MOCK_REF}/{MOCK_PATH}"
+MOCK_DOWNLOAD_URL = (
+    f"https://raw.githubusercontent.com/{MOCK_OWNER}/{MOCK_REPO}/{MOCK_REF}/{MOCK_PATH}"
+)
+MOCK_RAW_URL = (
+    f"https://raw.githubusercontent.com/{MOCK_OWNER}/{MOCK_REPO}/{MOCK_REF}/{MOCK_PATH}"
+)
+MOCK_RAW_TAG_URL = (
+    f"https://raw.githubusercontent.com/{MOCK_OWNER}/{MOCK_REPO}/"
+    f"refs/tags/{MOCK_REF}/{MOCK_PATH}"
+)
+MOCK_RAW_HEAD_URL = (
+    f"https://raw.githubusercontent.com/{MOCK_OWNER}/{MOCK_REPO}/"
+    f"refs/heads/{MOCK_REF}/{MOCK_PATH}"
+)
+
+MOCK_META = {
+    "name": "test.txt",
+    "size": len(MOCK_CONTENT),
+    "sha": MOCK_SHA,
+    "download_url": MOCK_DOWNLOAD_URL,
+}
+
+
+@pytest.fixture
+def mock_meta_response() -> MagicMock:
+    """Mock metadata response object."""
+    return MagicMock(json=MagicMock(return_value=MOCK_META))
+
+
+class TestGitHubFileMeta:
+    """Test suite for GitHub file metadata."""
+
+    def test_valid(self) -> None:
+        """Test metadata fields are correctly assigned on instantiation."""
+        meta = GitHubFileMeta(**MOCK_META)
+        assert meta.name == "test.txt"
+        assert meta.sha == MOCK_SHA
+        assert meta.download_url == MOCK_DOWNLOAD_URL
+
+
+class TestGitHubStorage:
+    """Test suite for GitHubStorage download and metadata retrieval."""
+
+    def test_parse_blob_url(self) -> None:
+        """Test blob URL is correctly parsed into owner/repo/ref/path."""
+        owner, repo, ref, path = GitHubStorage._parse(MOCK_URL)
+        assert owner == MOCK_OWNER
+        assert repo == MOCK_REPO
+        assert ref == MOCK_REF
+        assert path == MOCK_PATH
+
+    def test_parse_raw_url(self) -> None:
+        """Test bare raw URL is correctly parsed into owner/repo/ref/path."""
+        owner, repo, ref, path = GitHubStorage._parse(MOCK_RAW_URL)
+        assert owner == MOCK_OWNER
+        assert repo == MOCK_REPO
+        assert ref == MOCK_REF
+        assert path == MOCK_PATH
+
+    def test_parse_raw_tag_url(self) -> None:
+        """Test raw URL with refs/tags/ prefix is correctly parsed."""
+        owner, repo, ref, path = GitHubStorage._parse(MOCK_RAW_TAG_URL)
+        assert owner == MOCK_OWNER
+        assert repo == MOCK_REPO
+        assert ref == MOCK_REF
+        assert path == MOCK_PATH
+
+    def test_parse_raw_head_url(self) -> None:
+        """Test raw URL with refs/heads/ prefix is correctly parsed."""
+        owner, repo, ref, path = GitHubStorage._parse(MOCK_RAW_HEAD_URL)
+        assert owner == MOCK_OWNER
+        assert repo == MOCK_REPO
+        assert ref == MOCK_REF
+        assert path == MOCK_PATH
+
+    def test_parse_invalid_url_raises(self) -> None:
+        """Test parsing a non-GitHub URL raises ValueError."""
+        with pytest.raises(ValueError, match="Unrecognized GitHub URL"):
+            GitHubStorage._parse(f"https://github.com/{MOCK_OWNER}/{MOCK_REPO}")
+
+    @patch("neuromaps_prime.remote.github.requests.get")
+    def test_get_meta(self, mock_get: MagicMock, mock_meta_response: MagicMock) -> None:
+        """Test get_meta returns parsed GitHubFileMeta and calls correct URL."""
+        mock_get.return_value = mock_meta_response
+        meta = GitHubStorage().get_meta(MOCK_URL)
+        assert meta.name == "test.txt"
+        assert meta.sha == MOCK_SHA
+        mock_get.assert_called_once_with(
+            f"https://api.github.com/repos/{MOCK_OWNER}/{MOCK_REPO}/contents/{MOCK_PATH}",
+            params={"ref": MOCK_REF},
+            timeout=90,
+        )
+
+    @patch("neuromaps_prime.remote.github.requests.get")
+    def test_get_meta_raises_on_http_error(self, mock_get: MagicMock) -> None:
+        """Test get_meta propagates HTTP errors from the remote server."""
+        mock_get.return_value.raise_for_status.side_effect = Exception("HTTP Error")
+        with pytest.raises(Exception, match="HTTP Error"):
+            GitHubStorage().get_meta(MOCK_URL)
+
+    @patch("neuromaps_prime.remote.github.requests.get")
+    def test_download_valid(
+        self, mock_get: MagicMock, mock_meta_response: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test download writes correct bytes to dest when checksum matches."""
+        mock_download = MagicMock(iter_content=MagicMock(return_value=[MOCK_CONTENT]))
+        mock_get.side_effect = [mock_meta_response, mock_download]
+        dest = tmp_path / "test.txt"
+        GitHubStorage().download(MOCK_URL, dest)
+        assert dest.read_bytes() == MOCK_CONTENT
+
+    @patch("neuromaps_prime.remote.github.requests.get")
+    def test_download_checksum_mismatch(
+        self, mock_get: MagicMock, mock_meta_response: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test download raises ValueError when downloaded content fails checksum."""
+        mock_download = MagicMock(
+            iter_content=MagicMock(return_value=[b"wrong content"])
+        )
+        mock_get.side_effect = [mock_meta_response, mock_download]
+        with pytest.raises(ValueError, match="Checksum mismatch"):
+            GitHubStorage().download(MOCK_URL, tmp_path / "test.txt")
+
+    def test_default_chunk_size(self) -> None:
+        """Test chunk_size defaults to 8192."""
+        assert GitHubStorage().chunk_size == 8192
+
+    def test_custom_chunk_size(self) -> None:
+        """Test chunk_size is correctly set when provided."""
+        assert GitHubStorage(chunk_size=4096).chunk_size == 4096

--- a/tests/unit/test_fetcher.py
+++ b/tests/unit/test_fetcher.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
+from neuromaps_prime import remote
 from neuromaps_prime.fetcher import download_and_validate, id_storage
 
 if TYPE_CHECKING:
@@ -16,9 +17,20 @@ if TYPE_CHECKING:
 class TestIDStorage:
     """Test suite for identifying storage location."""
 
-    def test_osf(self) -> None:
-        """Test downloading from osf storage."""
-        assert id_storage("https://osf.io/project") == "osf"
+    @pytest.mark.parametrize(
+        ("storage", "expected"),
+        [
+            ("https://osf.io/project", "osf"),
+            ("https://github.com/owner", "github"),
+            (
+                "https://raw.githubusercontent.com/owner/repo/refs/tags/v1.0/file.txt",
+                "github",
+            ),
+        ],
+    )
+    def test_valid(self, storage: str, expected: str) -> None:
+        """Test downloading from valid storage options."""
+        assert id_storage(storage) == expected
 
     def test_unknown(self) -> None:
         """Test None returned if unknown uri."""
@@ -37,11 +49,22 @@ class TestDownloadAndValidate:
         with pytest.raises(ValueError, match="Could not identify storage"):
             download_and_validate("https://google.com", tmp_path / "invalid.txt")
 
-    @patch("neuromaps_prime.fetcher.OSFStorage")
-    def test_osf_calls_download(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        """Test OSF download."""
-        mock_osf = mock_cls.return_value
-        mock_uri = "https://files.osf.io/v1/resources/abcde"
+    @pytest.mark.parametrize(
+        ("storage_cls", "mock_uri"),
+        [
+            (remote.OSFStorage, "https://files.osf.io/v1/resources/abcde"),
+            (remote.GitHubStorage, "https://github.com/owner/repo/blob/v1.0/file.txt"),
+            (
+                remote.GitHubStorage,
+                "https://raw.githubusercontent.com/owner/repo/refs/tags/v1.0/file.txt",
+            ),
+        ],
+    )
+    def test_valid_calls_download(
+        self, storage_cls: object, mock_uri: str, tmp_path: Path
+    ) -> None:
+        """Test valid download."""
         dest = tmp_path / "out.surf.gii"
-        download_and_validate(mock_uri, dest)
-        mock_osf.download.assert_called_once_with(mock_uri, dest)
+        with patch.object(storage_cls, "download") as mock_download:
+            download_and_validate(mock_uri, dest)
+        mock_download.assert_called_once_with(mock_uri, dest)


### PR DESCRIPTION
## This PR:
* Adds `GitHubStorage` for fetching files from public GitHub repos via blob URLs (.../blob/{ref}/{path})
  * Mirrors existing `OSFStorage` interface (get_meta/download, checksum validation against git blob sha1). 
* Updates `fetcher.py` to dispatch to GitHub storage alongside OSF. 
* Adds/updates unit tests for GitHubStorage and fetcher dispatch (parametrized).

## Type of Change
- [ ] Bug fix
- [x] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)
- #188 by @kaitj 