### PR TITLE
Output references + caveats with option to save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,7 @@ __marimo__/
 styx_tmp/
 _version.py
 .python-version
+.notes/
 
 # Interactive graph output
 examples/interactive_graph.html

--- a/src/neuromaps_prime/graph/__init__.py
+++ b/src/neuromaps_prime/graph/__init__.py
@@ -25,6 +25,7 @@ from neuromaps_prime.graph import models
 from neuromaps_prime.graph.builder import GraphBuilder
 from neuromaps_prime.graph.cache import GraphCache
 from neuromaps_prime.graph.core import NeuromapsGraph
+from neuromaps_prime.graph.models import TransformResult
 from neuromaps_prime.graph.transforms.surface import SurfaceTransformOps
 from neuromaps_prime.graph.transforms.volume import VolumeTransformOps
 from neuromaps_prime.graph.utils import GraphUtils
@@ -35,6 +36,7 @@ __all__ = [
     "GraphUtils",
     "NeuromapsGraph",
     "SurfaceTransformOps",
+    "TransformResult",
     "VolumeTransformOps",
     "models",
 ]

--- a/src/neuromaps_prime/graph/__init__.py
+++ b/src/neuromaps_prime/graph/__init__.py
@@ -25,7 +25,7 @@ from neuromaps_prime.graph import models
 from neuromaps_prime.graph.builder import GraphBuilder
 from neuromaps_prime.graph.cache import GraphCache
 from neuromaps_prime.graph.core import NeuromapsGraph
-from neuromaps_prime.graph.models import TransformResult
+from neuromaps_prime.graph.models import TransformMetadata, TransformResult
 from neuromaps_prime.graph.transforms.surface import SurfaceTransformOps
 from neuromaps_prime.graph.transforms.volume import VolumeTransformOps
 from neuromaps_prime.graph.utils import GraphUtils
@@ -36,6 +36,7 @@ __all__ = [
     "GraphUtils",
     "NeuromapsGraph",
     "SurfaceTransformOps",
+    "TransformMetadata",
     "TransformResult",
     "VolumeTransformOps",
     "models",

--- a/src/neuromaps_prime/graph/__init__.py
+++ b/src/neuromaps_prime/graph/__init__.py
@@ -25,7 +25,12 @@ from neuromaps_prime.graph import models
 from neuromaps_prime.graph.builder import GraphBuilder
 from neuromaps_prime.graph.cache import GraphCache
 from neuromaps_prime.graph.core import NeuromapsGraph
-from neuromaps_prime.graph.models import TransformMetadata, TransformResult
+from neuromaps_prime.graph.models import (
+    HopMetadataDict,
+    SpaceMetadataDict,
+    TransformMetadata,
+    TransformResult,
+)
 from neuromaps_prime.graph.transforms.surface import SurfaceTransformOps
 from neuromaps_prime.graph.transforms.volume import VolumeTransformOps
 from neuromaps_prime.graph.utils import GraphUtils
@@ -34,7 +39,9 @@ __all__ = [
     "GraphBuilder",
     "GraphCache",
     "GraphUtils",
+    "HopMetadataDict",
     "NeuromapsGraph",
+    "SpaceMetadataDict",
     "SurfaceTransformOps",
     "TransformMetadata",
     "TransformResult",

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -18,6 +18,7 @@ from platformdirs import user_cache_dir
 
 from neuromaps_prime.graph.builder import GraphBuilder
 from neuromaps_prime.graph.cache import GraphCache
+from neuromaps_prime.graph.metadata import print_metadata_summary
 from neuromaps_prime.graph.models import (
     Edge,
     Node,
@@ -510,6 +511,11 @@ class NeuromapsGraph(nx.MultiDiGraph):
     # Transformers                                                         #
     # ------------------------------------------------------------------ #
 
+    def _print_metadata_if_verbose(self, result: TransformResult) -> None:
+        """Print a grouped metadata summary when verbosity is ≥ 1."""
+        if self.runner_ctx.verbose >= 1:
+            print_metadata_summary(result)
+
     def surface_to_surface_transformer(
         self,
         transformer_type: Literal["metric", "label"],
@@ -567,10 +573,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         )
 
         # Print metadata summary if verbose
-        if self.runner_ctx.verbose >= 1:
-            from neuromaps_prime.graph.metadata import print_metadata_summary
-
-            print_metadata_summary(result)
+        self._print_metadata_if_verbose(result)
 
         if metadata_path and result:
             result.save_metadata(metadata_path)
@@ -637,10 +640,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         )
 
         # Print metadata summary if verbose
-        if self.runner_ctx.verbose >= 1:
-            from neuromaps_prime.graph.metadata import print_metadata_summary
-
-            print_metadata_summary(result)
+        self._print_metadata_if_verbose(result)
 
         if metadata_path and result:
             result.save_metadata(metadata_path)
@@ -699,10 +699,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         )
 
         # Print metadata summary if verbose
-        if self.runner_ctx.verbose >= 1:
-            from neuromaps_prime.graph.metadata import print_metadata_summary
-
-            print_metadata_summary(result)
+        self._print_metadata_if_verbose(result)
 
         if metadata_path and result:
             result.save_metadata(metadata_path)
@@ -766,10 +763,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         )
 
         # Print metadata summary if verbose
-        if self.runner_ctx.verbose >= 1:
-            from neuromaps_prime.graph.metadata import print_metadata_summary
-
-            print_metadata_summary(result)
+        self._print_metadata_if_verbose(result)
 
         if metadata_path and result:
             result.save_metadata(metadata_path)

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -549,20 +549,18 @@ class NeuromapsGraph(nx.MultiDiGraph):
             the output path. Acts like a :class:`~pathlib.Path` when used
             without attribute access.
         """
-        return TransformResult(
-            self.surface_ops.transform_surface(
-                transformer_type=transformer_type,
-                input_file=input_file,
-                source_space=source_space,
-                target_space=target_space,
-                hemisphere=hemisphere,
-                output_file_path=output_file_path,
-                source_density=source_density,
-                target_density=target_density,
-                area_resource=area_resource,
-                add_edge=add_edge,
-                provider=provider,
-            )
+        return self.surface_ops.transform_surface(
+            transformer_type=transformer_type,
+            input_file=input_file,
+            source_space=source_space,
+            target_space=target_space,
+            hemisphere=hemisphere,
+            output_file_path=output_file_path,
+            source_density=source_density,
+            target_density=target_density,
+            area_resource=area_resource,
+            add_edge=add_edge,
+            provider=provider,
         )
 
     def surface_to_volume_transformer(
@@ -606,22 +604,20 @@ class NeuromapsGraph(nx.MultiDiGraph):
             the output path. Acts like a :class:`~pathlib.Path` when used
             without attribute access.
         """
-        return TransformResult(  # pragma: no cover
-            self.surface_ops.transform_surface_to_volume(
-                transformer_type=transformer_type,
-                input_file=input_file,
-                ref_volume=ref_volume,
-                source_space=source_space,
-                target_space=target_space,
-                hemisphere=hemisphere,
-                output_file_path=output_file_path,
-                source_density=source_density,
-                target_density=target_density,
-                area_resource=area_resource,
-                add_edge=add_edge,
-                provider=provider,
-            )
-        )
+        return self.surface_ops.transform_surface_to_volume(
+            transformer_type=transformer_type,
+            input_file=input_file,
+            ref_volume=ref_volume,
+            source_space=source_space,
+            target_space=target_space,
+            hemisphere=hemisphere,
+            output_file_path=output_file_path,
+            source_density=source_density,
+            target_density=target_density,
+            area_resource=area_resource,
+            add_edge=add_edge,
+            provider=provider,
+        )  # pragma: no cover
 
     def volume_to_volume_transformer(
         self,
@@ -658,19 +654,17 @@ class NeuromapsGraph(nx.MultiDiGraph):
             the output path. Acts like a :class:`~pathlib.Path` when used
             without attribute access.
         """
-        return TransformResult(
-            self.volume_ops.transform_volume(
-                input_file=input_file,
-                source_space=source_space,
-                target_space=target_space,
-                resolution=resolution,
-                resource_type=resource_type,
-                output_file_path=output_file_path,
-                interp=interp,
-                interp_params=interp_params,
-                atlas_resource_type=atlas_resource_type,
-                provider=provider,
-            )
+        return self.volume_ops.transform_volume(
+            input_file=input_file,
+            source_space=source_space,
+            target_space=target_space,
+            resolution=resolution,
+            resource_type=resource_type,
+            output_file_path=output_file_path,
+            interp=interp,
+            interp_params=interp_params,
+            atlas_resource_type=atlas_resource_type,
+            provider=provider,
         )
 
     def volume_to_surface_transformer(
@@ -712,18 +706,16 @@ class NeuromapsGraph(nx.MultiDiGraph):
             the output path. Acts like a :class:`~pathlib.Path` when used
             without attribute access.
         """
-        return TransformResult(
-            self.volume_ops.transform_volume_to_surface(
-                transformer_type=transformer_type,
-                input_file=input_file,
-                source_space=source_space,
-                target_space=target_space,
-                hemisphere=hemisphere,
-                output_file_path=output_file_path,
-                source_density=source_density,
-                target_density=target_density,
-                area_resource=area_resource,
-                add_edge=add_edge,
-                provider=provider,
-            )
+        return self.volume_ops.transform_volume_to_surface(
+            transformer_type=transformer_type,
+            input_file=input_file,
+            source_space=source_space,
+            target_space=target_space,
+            hemisphere=hemisphere,
+            output_file_path=output_file_path,
+            source_density=source_density,
+            target_density=target_density,
+            area_resource=area_resource,
+            add_edge=add_edge,
+            provider=provider,
         )

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -523,6 +523,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         area_resource: str = "midthickness",
         *,
         add_edge: bool = True,
+        metadata_path: Path | None = None,
         provider: str | None = None,
     ) -> TransformResult:
         """Resample a metric or label GIFTI from source_space to target_space.
@@ -541,6 +542,8 @@ class NeuromapsGraph(nx.MultiDiGraph):
             area_resource: Surface type for area correction
                 (default ``'midthickness'``).
             add_edge: Whether to register composed transforms.
+            metadata_path: Optional path to write metadata to. Format is
+                inferred from the file extension (``.md`` or ``.json``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 
@@ -569,6 +572,9 @@ class NeuromapsGraph(nx.MultiDiGraph):
 
             print_metadata_summary(result)
 
+        if metadata_path and result:
+            result.save_metadata(metadata_path)
+
         return result
 
     def surface_to_volume_transformer(
@@ -585,6 +591,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         area_resource: str = "midthickness",
         *,
         add_edge: bool = True,
+        metadata_path: Path | None = None,
         provider: str | None = None,
     ) -> TransformResult:
         """Project a volume to surface then resample to target_space.
@@ -604,6 +611,8 @@ class NeuromapsGraph(nx.MultiDiGraph):
             area_resource: Surface type for area correction
                 (default ``'midthickness'``).
             add_edge: Whether to register composed transforms.
+            metadata_path: Optional path to write metadata to. Format is
+                inferred from the file extension (``.md`` or ``.json``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 
@@ -633,6 +642,9 @@ class NeuromapsGraph(nx.MultiDiGraph):
 
             print_metadata_summary(result)
 
+        if metadata_path and result:
+            result.save_metadata(metadata_path)
+
         return result  # pragma: no cover
 
     def volume_to_volume_transformer(
@@ -647,6 +659,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         interp_params: dict[str, Any] | None = None,
         atlas_resource_type: str = "T1w",
         *,
+        metadata_path: Path | None = None,
         provider: str | None = None,
     ) -> TransformResult:
         """Warp a volume image from source_space to target_space.
@@ -662,6 +675,8 @@ class NeuromapsGraph(nx.MultiDiGraph):
             interp_params: Optional interpolation parameters.
             atlas_resource_type: Volume resource type for the reference atlas
                 lookup (default ``'T1w'``).
+            metadata_path: Optional path to write metadata to. Format is
+                inferred from the file extension (``.md`` or ``.json``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 
@@ -689,6 +704,9 @@ class NeuromapsGraph(nx.MultiDiGraph):
 
             print_metadata_summary(result)
 
+        if metadata_path and result:
+            result.save_metadata(metadata_path)
+
         return result
 
     def volume_to_surface_transformer(
@@ -704,6 +722,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         area_resource: str = "midthickness",
         *,
         add_edge: bool = True,
+        metadata_path: Path | None = None,
         provider: str | None = None,
     ) -> TransformResult:
         """Project a volume to surface then resample to target_space.
@@ -722,6 +741,8 @@ class NeuromapsGraph(nx.MultiDiGraph):
             area_resource: Surface type for area correction
                 (default ``'midthickness'``).
             add_edge: Whether to register composed transforms.
+            metadata_path: Optional path to write metadata to. Format is
+                inferred from the file extension (``.md`` or ``.json``).
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 
@@ -749,5 +770,8 @@ class NeuromapsGraph(nx.MultiDiGraph):
             from neuromaps_prime.graph.metadata import print_metadata_summary
 
             print_metadata_summary(result)
+
+        if metadata_path and result:
+            result.save_metadata(metadata_path)
 
         return result

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -24,6 +24,7 @@ from neuromaps_prime.graph.models import (
     SurfaceAnnotation,
     SurfaceAtlas,
     SurfaceTransform,
+    TransformResult,
     VolumeAnnotation,
     VolumeAtlas,
     VolumeTransform,
@@ -523,7 +524,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         *,
         add_edge: bool = True,
         provider: str | None = None,
-    ) -> Path | None:
+    ) -> TransformResult:
         """Resample a metric or label GIFTI from source_space to target_space.
 
         Args:
@@ -544,21 +545,24 @@ class NeuromapsGraph(nx.MultiDiGraph):
                 registered provider when ``None``.
 
         Returns:
-            Path to the resampled output, or ``None`` if the transform could
-            not be resolved.
+            :class:`~neuromaps_prime.graph.models.TransformResult` containing
+            the output path. Acts like a :class:`~pathlib.Path` when used
+            without attribute access.
         """
-        return self.surface_ops.transform_surface(
-            transformer_type=transformer_type,
-            input_file=input_file,
-            source_space=source_space,
-            target_space=target_space,
-            hemisphere=hemisphere,
-            output_file_path=output_file_path,
-            source_density=source_density,
-            target_density=target_density,
-            area_resource=area_resource,
-            add_edge=add_edge,
-            provider=provider,
+        return TransformResult(
+            self.surface_ops.transform_surface(
+                transformer_type=transformer_type,
+                input_file=input_file,
+                source_space=source_space,
+                target_space=target_space,
+                hemisphere=hemisphere,
+                output_file_path=output_file_path,
+                source_density=source_density,
+                target_density=target_density,
+                area_resource=area_resource,
+                add_edge=add_edge,
+                provider=provider,
+            )
         )
 
     def surface_to_volume_transformer(
@@ -576,7 +580,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         *,
         add_edge: bool = True,
         provider: str | None = None,
-    ) -> Path | None:
+    ) -> TransformResult:
         """Project a volume to surface then resample to target_space.
 
         Args:
@@ -598,21 +602,25 @@ class NeuromapsGraph(nx.MultiDiGraph):
                 registered provider when ``None``.
 
         Returns:
-            Path to the surface resampled to volume.
+            :class:`~neuromaps_prime.graph.models.TransformResult` containing
+            the output path. Acts like a :class:`~pathlib.Path` when used
+            without attribute access.
         """
-        return self.surface_ops.transform_surface_to_volume(  # pragma: no cover
-            transformer_type=transformer_type,
-            input_file=input_file,
-            ref_volume=ref_volume,
-            source_space=source_space,
-            target_space=target_space,
-            hemisphere=hemisphere,
-            output_file_path=output_file_path,
-            source_density=source_density,
-            target_density=target_density,
-            area_resource=area_resource,
-            add_edge=add_edge,
-            provider=provider,
+        return TransformResult(  # pragma: no cover
+            self.surface_ops.transform_surface_to_volume(
+                transformer_type=transformer_type,
+                input_file=input_file,
+                ref_volume=ref_volume,
+                source_space=source_space,
+                target_space=target_space,
+                hemisphere=hemisphere,
+                output_file_path=output_file_path,
+                source_density=source_density,
+                target_density=target_density,
+                area_resource=area_resource,
+                add_edge=add_edge,
+                provider=provider,
+            )
         )
 
     def volume_to_volume_transformer(
@@ -628,7 +636,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         atlas_resource_type: str = "T1w",
         *,
         provider: str | None = None,
-    ) -> Path:
+    ) -> TransformResult:
         """Warp a volume image from source_space to target_space.
 
         Args:
@@ -646,19 +654,23 @@ class NeuromapsGraph(nx.MultiDiGraph):
                 registered provider when ``None``.
 
         Returns:
-            Path to the warped output volume.
+            :class:`~neuromaps_prime.graph.models.TransformResult` containing
+            the output path. Acts like a :class:`~pathlib.Path` when used
+            without attribute access.
         """
-        return self.volume_ops.transform_volume(
-            input_file=input_file,
-            source_space=source_space,
-            target_space=target_space,
-            resolution=resolution,
-            resource_type=resource_type,
-            output_file_path=output_file_path,
-            interp=interp,
-            interp_params=interp_params,
-            atlas_resource_type=atlas_resource_type,
-            provider=provider,
+        return TransformResult(
+            self.volume_ops.transform_volume(
+                input_file=input_file,
+                source_space=source_space,
+                target_space=target_space,
+                resolution=resolution,
+                resource_type=resource_type,
+                output_file_path=output_file_path,
+                interp=interp,
+                interp_params=interp_params,
+                atlas_resource_type=atlas_resource_type,
+                provider=provider,
+            )
         )
 
     def volume_to_surface_transformer(
@@ -675,7 +687,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
         *,
         add_edge: bool = True,
         provider: str | None = None,
-    ) -> Path | None:
+    ) -> TransformResult:
         """Project a volume to surface then resample to target_space.
 
         Args:
@@ -696,19 +708,22 @@ class NeuromapsGraph(nx.MultiDiGraph):
                 registered provider when ``None``.
 
         Returns:
-            Path to the resampled output, or ``None`` if the transform could
-            not be resolved.
+            :class:`~neuromaps_prime.graph.models.TransformResult` containing
+            the output path. Acts like a :class:`~pathlib.Path` when used
+            without attribute access.
         """
-        return self.volume_ops.transform_volume_to_surface(
-            transformer_type=transformer_type,
-            input_file=input_file,
-            source_space=source_space,
-            target_space=target_space,
-            hemisphere=hemisphere,
-            output_file_path=output_file_path,
-            source_density=source_density,
-            target_density=target_density,
-            area_resource=area_resource,
-            add_edge=add_edge,
-            provider=provider,
+        return TransformResult(
+            self.volume_ops.transform_volume_to_surface(
+                transformer_type=transformer_type,
+                input_file=input_file,
+                source_space=source_space,
+                target_space=target_space,
+                hemisphere=hemisphere,
+                output_file_path=output_file_path,
+                source_density=source_density,
+                target_density=target_density,
+                area_resource=area_resource,
+                add_edge=add_edge,
+                provider=provider,
+            )
         )

--- a/src/neuromaps_prime/graph/core.py
+++ b/src/neuromaps_prime/graph/core.py
@@ -549,7 +549,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
             the output path. Acts like a :class:`~pathlib.Path` when used
             without attribute access.
         """
-        return self.surface_ops.transform_surface(
+        result = self.surface_ops.transform_surface(
             transformer_type=transformer_type,
             input_file=input_file,
             source_space=source_space,
@@ -562,6 +562,14 @@ class NeuromapsGraph(nx.MultiDiGraph):
             add_edge=add_edge,
             provider=provider,
         )
+
+        # Print metadata summary if verbose
+        if self.runner_ctx.verbose >= 1:
+            from neuromaps_prime.graph.metadata import print_metadata_summary
+
+            print_metadata_summary(result)
+
+        return result
 
     def surface_to_volume_transformer(
         self,
@@ -604,7 +612,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
             the output path. Acts like a :class:`~pathlib.Path` when used
             without attribute access.
         """
-        return self.surface_ops.transform_surface_to_volume(
+        result = self.surface_ops.transform_surface_to_volume(
             transformer_type=transformer_type,
             input_file=input_file,
             ref_volume=ref_volume,
@@ -617,7 +625,15 @@ class NeuromapsGraph(nx.MultiDiGraph):
             area_resource=area_resource,
             add_edge=add_edge,
             provider=provider,
-        )  # pragma: no cover
+        )
+
+        # Print metadata summary if verbose
+        if self.runner_ctx.verbose >= 1:
+            from neuromaps_prime.graph.metadata import print_metadata_summary
+
+            print_metadata_summary(result)
+
+        return result  # pragma: no cover
 
     def volume_to_volume_transformer(
         self,
@@ -654,7 +670,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
             the output path. Acts like a :class:`~pathlib.Path` when used
             without attribute access.
         """
-        return self.volume_ops.transform_volume(
+        result = self.volume_ops.transform_volume(
             input_file=input_file,
             source_space=source_space,
             target_space=target_space,
@@ -666,6 +682,14 @@ class NeuromapsGraph(nx.MultiDiGraph):
             atlas_resource_type=atlas_resource_type,
             provider=provider,
         )
+
+        # Print metadata summary if verbose
+        if self.runner_ctx.verbose >= 1:
+            from neuromaps_prime.graph.metadata import print_metadata_summary
+
+            print_metadata_summary(result)
+
+        return result
 
     def volume_to_surface_transformer(
         self,
@@ -706,7 +730,7 @@ class NeuromapsGraph(nx.MultiDiGraph):
             the output path. Acts like a :class:`~pathlib.Path` when used
             without attribute access.
         """
-        return self.volume_ops.transform_volume_to_surface(
+        result = self.volume_ops.transform_volume_to_surface(
             transformer_type=transformer_type,
             input_file=input_file,
             source_space=source_space,
@@ -719,3 +743,11 @@ class NeuromapsGraph(nx.MultiDiGraph):
             add_edge=add_edge,
             provider=provider,
         )
+
+        # Print metadata summary if verbose
+        if self.runner_ctx.verbose >= 1:
+            from neuromaps_prime.graph.metadata import print_metadata_summary
+
+            print_metadata_summary(result)
+
+        return result

--- a/src/neuromaps_prime/graph/metadata.py
+++ b/src/neuromaps_prime/graph/metadata.py
@@ -1,0 +1,33 @@
+"""Metadata helpers for transformation pipelines.
+
+Provides utilities to format structured references into human-readable
+strings.  Merging of references/notes during transform composition is
+done inline to keep the surface/volume ops modules self-contained.
+"""
+
+from __future__ import annotations
+
+
+def format_reference(ref: str | dict[str, str]) -> str:
+    """Combine a structured reference into a single human-readable string.
+
+    String references are returned as-is.  Dict references are joined with
+    `` | `` using the ``citation``, ``doi``, and ``url`` keys when present.
+
+    Args:
+        ref: Either a plain citation string or a structured dict.
+
+    Returns:
+        A single formatted reference string.
+    """
+    if isinstance(ref, str):
+        return ref
+
+    parts = []
+    if citation := ref.get("citation"):
+        parts.append(citation)
+    if doi := ref.get("doi"):
+        parts.append(f"DOI: {doi}")
+    if url := ref.get("url"):
+        parts.append(f"URL: {url}")
+    return " | ".join(parts)

--- a/src/neuromaps_prime/graph/metadata.py
+++ b/src/neuromaps_prime/graph/metadata.py
@@ -1,11 +1,24 @@
 """Metadata helpers for transformation pipelines.
 
 Provides utilities to format structured references into human-readable
-strings.  Merging of references/notes during transform composition is
-done inline to keep the surface/volume ops modules self-contained.
+strings and print grouped summaries.  Merging of references/notes during
+transform composition is done inline to keep the surface/volume ops
+modules self-contained.
 """
 
 from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, TextIO
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from neuromaps_prime.graph.models import (
+        HopMetadataDict,
+        SpaceMetadataDict,
+        TransformResult,
+    )
 
 
 def format_reference(ref: str | dict[str, str]) -> str:
@@ -31,3 +44,104 @@ def format_reference(ref: str | dict[str, str]) -> str:
     if url := ref.get("url"):
         parts.append(f"URL: {url}")
     return " | ".join(parts)
+
+
+def _build_space_path(hops: Sequence[HopMetadataDict]) -> list[str]:
+    """Extract ordered space sequence from hop metadata.
+
+    Args:
+        hops: Per-hop metadata dicts.
+
+    Returns:
+        Ordered list of unique space names forming the transform path.
+    """
+    space_names: list[str] = []
+    for hop in hops:
+        src = hop.get("source_space", "")
+        if src and (not space_names or space_names[-1] != src):
+            space_names.append(src)
+        tgt = hop.get("target_space", "")
+        if tgt and tgt not in space_names:
+            space_names.append(tgt)
+    return space_names
+
+
+def _print_spaces(
+    spaces: Sequence[SpaceMetadataDict],
+    out: Callable[..., None],
+) -> None:
+    """Print node-level space references.
+
+    Args:
+        spaces: Per-space metadata dicts.
+        out: print function configured with the target file.
+    """
+    out("--- Spaces ---")
+    for space in spaces:
+        name = space.get("space", "Unknown")
+        refs = space.get("references") or []
+        out(f"  {name}:")
+        for ref in refs:
+            out(f"    Ref: {ref}")
+    out()
+
+
+def _print_hop(
+    hop: HopMetadataDict,
+    out: Callable[..., None],
+) -> None:
+    """Print a single hop's references and caveats.
+
+    Args:
+        hop: Per-hop metadata dict.
+        out: print function configured with the target file.
+    """
+    src = hop.get("source_space", "")
+    tgt = hop.get("target_space", "")
+    provider = hop.get("provider", "")
+    out(f"--- {src} -> {tgt} [{provider}] ---")
+
+    refs = hop.get("references") or []
+    if refs:
+        out("  References:")
+        for ref in refs:
+            out(f"    - {ref}")
+
+    notes = hop.get("notes") or []
+    if notes:
+        out("  Caveats:")
+        for note in notes:
+            out(f"    - {note}")
+    out()
+
+
+def print_metadata_summary(
+    result: TransformResult,
+    file: TextIO | None = None,
+) -> None:
+    """Print a grouped metadata summary to stdout.
+
+    Prints node-level references under a 'Spaces' header, then per-hop
+    transform references and caveats. Does nothing if the result has no
+    metadata or is falsy.
+
+    Args:
+        result: TransformResult carrying structured provenance metadata.
+        file: File-like object to write to. Defaults to stdout.
+    """
+    if not result or result.metadata is None:
+        return
+
+    out = partial(print, file=file)
+    hops = result.metadata.transforms or []
+    out(f"=== Transformation: {' -> '.join(_build_space_path(hops))} ===")
+    out()
+
+    spaces = result.metadata.spaces or []
+    if spaces:
+        _print_spaces(spaces, out)
+
+    for hop in hops:
+        _print_hop(hop, out)
+
+    out("=== End ===")

--- a/src/neuromaps_prime/graph/models.py
+++ b/src/neuromaps_prime/graph/models.py
@@ -223,6 +223,12 @@ class TransformMetadata:
         self.transforms = list(transforms) if transforms is not None else None
         self.spaces = list(spaces) if spaces is not None else None
 
+    def __eq__(self, other: object) -> bool:
+        """Compare two TransformMetadata instances by value."""
+        if not isinstance(other, TransformMetadata):
+            return NotImplemented
+        return self.transforms == other.transforms and self.spaces == other.spaces
+
 
 class TransformResult:
     """Result of a transformation, including output path and metadata.
@@ -267,9 +273,9 @@ class TransformResult:
             return None
         refs: list[str] = []
         for space in self.metadata.spaces or ():
-            refs.extend(space.get("references") or ())  # type: ignore[arg-type]
+            refs.extend(space.get("references", ()))
         for hop in self.metadata.transforms or ():
-            refs.extend(hop.get("references") or ())  # type: ignore[arg-type]
+            refs.extend(hop.get("references", ()))
         return refs or None
 
     @property
@@ -282,7 +288,7 @@ class TransformResult:
             return None
         notes: list[str] = []
         for hop in self.metadata.transforms or ():
-            notes.extend(hop.get("notes") or ())  # type: ignore[arg-type]
+            notes.extend(hop.get("notes", ()))
         return notes or None
 
     # --- Path-like protocol ---

--- a/src/neuromaps_prime/graph/models.py
+++ b/src/neuromaps_prime/graph/models.py
@@ -149,3 +149,100 @@ class Edge(BaseModel):
         surface_str = "\n".join(s.name for s in self.surface_transforms)
         volume_str = "\n".join(v.name for v in self.volume_transforms)
         return f"\nEdge:\n\tsurfaces=[{surface_str}],\n\tvolumes=[{volume_str}]"
+
+
+class TransformResult:
+    """Result of a transformation, including output path and metadata.
+
+    When used without attribute access—printing, f-strings, passing to
+    ``os.path.*`` or ``nibabel``—behaves like a :class:`~pathlib.Path`.
+    Access :attr:`references` and :attr:`notes` for transformation metadata.
+
+    Attributes:
+        path: Output file path, or ``None`` if the transform failed.
+        references: Combined citation strings for all transforms used,
+            or ``None`` if metadata collection was not requested.
+        notes: Caveats and warnings for all transforms used,
+            or ``None`` if metadata collection was not requested.
+    """
+
+    def __init__(
+        self,
+        output_path: Path | None = None,
+        references: Sequence[str] | None = None,
+        notes: Sequence[str] | None = None,
+    ) -> None:
+        """Initialize TransformResult.
+
+        Args:
+            output_path: Path to the output file, or ``None`` on failure.
+            references: Combined citation strings for all transforms used.
+            notes: Caveats and warnings for all transforms used.
+        """
+        self._output_path = output_path
+        self.path = output_path
+        self.references: Sequence[str] | None = references
+        self.notes: Sequence[str] | None = notes
+
+    # --- Path-like protocol ---
+
+    def __eq__(self, other: object) -> bool:
+        """Compare with :class:`~pathlib.Path` or another :class:`TransformResult`.
+
+        When comparing to a :class:`~pathlib.Path`, only the output path is
+        considered. When comparing to another :class:`TransformResult`, all
+        fields are compared.
+        """
+        if isinstance(other, TransformResult):
+            return (
+                self._output_path == other._output_path
+                and self.references == other.references
+                and self.notes == other.notes
+            )
+        return self._output_path == other
+
+    def __fspath__(self) -> str:
+        """Return the filesystem path string.
+
+        Raises:
+            TypeError: If the output path is ``None``.
+        """
+        if self._output_path is None:
+            raise TypeError("Cannot get filesystem path from None result")
+        return str(self._output_path)
+
+    def __bool__(self) -> bool:
+        """Return ``True`` if the transform succeeded (path is not ``None``)."""
+        return self._output_path is not None
+
+    def __str__(self) -> str:
+        """Return the output path string."""
+        return str(self._output_path) if self._output_path else "<None>"
+
+    def __repr__(self) -> str:
+        """Return the debug representation."""
+        return (
+            f"TransformResult(path={self._output_path!r}, "
+            f"refs={len(self.references) if self.references else 0}, "
+            f"notes={len(self.notes) if self.notes else 0})"
+        )
+
+    # --- Path method delegation (test compatibility) ---
+
+    def exists(self) -> bool:
+        """Delegate to :meth:`Path.exists`."""
+        return self._output_path.exists() if self._output_path else False
+
+    @property
+    def parent(self) -> Path | None:
+        """Parent directory of the output path."""
+        return self._output_path.parent if self._output_path else None
+
+    @property
+    def name(self) -> str:
+        """Basename of the output file."""
+        return self._output_path.name if self._output_path else ""
+
+    def is_file(self) -> bool:
+        """Delegate to :meth:`Path.is_file`."""
+        return self._output_path.is_file() if self._output_path else False

--- a/src/neuromaps_prime/graph/models.py
+++ b/src/neuromaps_prime/graph/models.py
@@ -10,6 +10,7 @@ from typing import Literal, TypedDict
 from pydantic import BaseModel, Field
 
 from neuromaps_prime.fetcher import download_and_validate
+from neuromaps_prime.graph.metadata import _build_space_path
 
 _logger = logging.getLogger(__name__)
 
@@ -219,8 +220,8 @@ class TransformMetadata:
             transforms: Per-hop metadata dicts.
             spaces: Per-space node-level reference dicts.
         """
-        self.transforms = transforms
-        self.spaces = spaces
+        self.transforms = list(transforms) if transforms is not None else None
+        self.spaces = list(spaces) if spaces is not None else None
 
 
 class TransformResult:
@@ -447,15 +448,7 @@ class TransformResult:
         """Extract ordered space sequence from hop metadata."""
         if self.metadata is None or self.metadata.transforms is None:
             return []
-        space_names: list[str] = []
-        for hop in self.metadata.transforms:
-            src = hop.get("source_space", "")
-            if src and (not space_names or space_names[-1] != src):
-                space_names.append(src)
-            tgt = hop.get("target_space", "")
-            if tgt and tgt not in space_names:
-                space_names.append(tgt)
-        return space_names
+        return _build_space_path(self.metadata.transforms)
 
     def _write_json(
         self,

--- a/src/neuromaps_prime/graph/models.py
+++ b/src/neuromaps_prime/graph/models.py
@@ -1,5 +1,7 @@
 """Models for resources in the neuromaps_prime graph."""
 
+import datetime
+import json
 import logging
 from collections.abc import Sequence
 from pathlib import Path
@@ -10,6 +12,17 @@ from pydantic import BaseModel, Field
 from neuromaps_prime.fetcher import download_and_validate
 
 _logger = logging.getLogger(__name__)
+
+
+class _SerializedEntry(TypedDict, total=False):
+    """TypedDict for serialized metadata entry (space or transform hop)."""
+
+    space: str
+    source_space: str
+    target_space: str
+    provider: str
+    references: list[str]
+    notes: list[str]
 
 
 class Resource(BaseModel):
@@ -334,3 +347,203 @@ class TransformResult:
     def is_file(self) -> bool:
         """Delegate to :meth:`Path.is_file`."""
         return self._output_path.is_file() if self._output_path else False
+
+    # --- Disk serialization ---
+
+    def save_metadata(
+        self,
+        metadata_path: Path | None = None,
+    ) -> Path:
+        """Save per-hop and node-level metadata to disk.
+
+        Format is inferred from the file extension:
+
+        - ``.md`` → Markdown (human-readable)
+        - ``.json`` → structured JSON
+
+        Args:
+            metadata_path: Destination file path. Defaults to
+                ``<output>.md``.
+
+        Returns:
+            Path to the written metadata file.
+
+        Raises:
+            ValueError: If the output path is ``None``.
+            NotImplementedError: If the file extension is not
+                ``.md`` or ``.json``.
+        """
+        if self._output_path is None:
+            raise ValueError("Cannot save metadata: output path is None")
+
+        if metadata_path is None:
+            metadata_path = Path(str(self.path) + ".md")
+
+        ext = metadata_path.suffix.lower()
+        if ext not in (".md", ".json"):
+            raise NotImplementedError(
+                f"Unsupported file extension '{ext}'. "
+                "Use '.md' for Markdown or '.json' for JSON."
+            )
+
+        spaces_out = self._serialize_spaces()
+        transforms_out = self._serialize_transforms()
+        transform_path = self._build_space_path()
+
+        if ext == ".json":
+            self._write_json(metadata_path, transform_path, spaces_out, transforms_out)
+        else:
+            content = self._format_markdown(transform_path, spaces_out, transforms_out)
+            metadata_path.write_text(content)
+
+        return metadata_path
+
+    def _serialize_spaces(
+        self,
+    ) -> list[_SerializedEntry] | None:
+        """Convert space metadata to serializable dicts."""
+        if self.metadata is None or not self.metadata.spaces:
+            return None
+        result: list[_SerializedEntry] = []
+        for space in self.metadata.spaces:
+            entry: _SerializedEntry = {}
+            name = space.get("space")
+            if name:
+                entry["space"] = name
+            refs = space.get("references")
+            if refs:
+                entry["references"] = list(refs)
+            result.append(entry)
+        return result
+
+    def _serialize_transforms(
+        self,
+    ) -> list[_SerializedEntry] | None:
+        """Convert transform hop metadata to serializable dicts."""
+        if self.metadata is None or not self.metadata.transforms:
+            return None
+        result: list[_SerializedEntry] = []
+        for hop in self.metadata.transforms:
+            entry: _SerializedEntry = {}
+            src = hop.get("source_space")
+            if src:
+                entry["source_space"] = src
+            tgt = hop.get("target_space")
+            if tgt:
+                entry["target_space"] = tgt
+            prov = hop.get("provider")
+            if prov:
+                entry["provider"] = prov
+            refs = hop.get("references")
+            if refs:
+                entry["references"] = list(refs)
+            notes = hop.get("notes")
+            if notes:
+                entry["notes"] = list(notes)
+            result.append(entry)
+        return result
+
+    def _build_space_path(self) -> list[str]:
+        """Extract ordered space sequence from hop metadata."""
+        if self.metadata is None or self.metadata.transforms is None:
+            return []
+        space_names: list[str] = []
+        for hop in self.metadata.transforms:
+            src = hop.get("source_space", "")
+            if src and (not space_names or space_names[-1] != src):
+                space_names.append(src)
+            tgt = hop.get("target_space", "")
+            if tgt and tgt not in space_names:
+                space_names.append(tgt)
+        return space_names
+
+    def _write_json(
+        self,
+        metadata_path: Path,
+        transform_path: list[str],
+        spaces: list[_SerializedEntry] | None,
+        transforms: list[_SerializedEntry] | None,
+    ) -> None:
+        """Write metadata as a JSON file."""
+        doc: dict[str, str | list[str] | list[_SerializedEntry]] = {
+            "output_file": str(self.path)
+        }
+        if transform_path:
+            doc["transform_path"] = transform_path
+        if spaces:
+            doc["spaces"] = spaces
+        if transforms:
+            doc["transforms"] = transforms
+        doc["timestamp"] = datetime.datetime.now(datetime.UTC).isoformat()
+        metadata_path.write_text(json.dumps(doc, indent=2) + "\n")
+
+    def _format_markdown(
+        self,
+        transform_path: list[str],
+        spaces: list[_SerializedEntry] | None,
+        transforms: list[_SerializedEntry] | None,
+    ) -> str:
+        """Build a Markdown representation of the metadata."""
+        lines: list[str] = []
+        self._write_header(lines, transform_path)
+        self._write_spaces_section(lines, spaces)
+        self._write_transforms_section(lines, transforms)
+        lines.append(
+            f"*Generated at {datetime.datetime.now(datetime.UTC).isoformat()}*"
+        )
+        lines.append("")
+        return "\n".join(lines)
+
+    def _write_header(self, lines: list[str], transform_path: list[str]) -> None:
+        """Write the Markdown transformation header."""
+        if transform_path:
+            header = " -> ".join(transform_path)
+        elif self._output_path:
+            header = str(self._output_path.name)
+        else:
+            header = "Transformation"
+        lines.append(f"# Transformation: {header}")
+        lines.append("")
+
+    def _write_spaces_section(
+        self, lines: list[str], spaces: list[_SerializedEntry] | None
+    ) -> None:
+        """Write the Markdown spaces section."""
+        if not spaces:
+            return
+        lines.append("## Spaces")
+        lines.append("")
+        for space in spaces:
+            space_name = space.get("space", "Unknown")
+            lines.append(f"### {space_name}")
+            lines.append("")
+            refs = space.get("references")
+            if refs:
+                lines.extend(f"- {r}" for r in refs)
+                lines.append("")
+
+    def _write_transforms_section(
+        self, lines: list[str], transforms: list[_SerializedEntry] | None
+    ) -> None:
+        """Write the Markdown transforms section."""
+        if not transforms:
+            return
+        lines.append("## Transforms")
+        lines.append("")
+        for hop in transforms:
+            src = hop.get("source_space", "?")
+            tgt = hop.get("target_space", "?")
+            prov = hop.get("provider", "")
+            prov_str = f" [{prov}]" if prov else ""
+            lines.append(f"### {src} -> {tgt}{prov_str}")
+            lines.append("")
+            refs = hop.get("references")
+            if refs:
+                lines.append("**References:**")
+                lines.extend(f"- {r}" for r in refs)
+                lines.append("")
+            notes = hop.get("notes")
+            if notes:
+                lines.append("**Caveats:**")
+                lines.extend(f"- {n}" for n in notes)
+                lines.append("")

--- a/src/neuromaps_prime/graph/models.py
+++ b/src/neuromaps_prime/graph/models.py
@@ -151,38 +151,95 @@ class Edge(BaseModel):
         return f"\nEdge:\n\tsurfaces=[{surface_str}],\n\tvolumes=[{volume_str}]"
 
 
+class TransformMetadata:
+    """Encapsulates provenance metadata for a transform pipeline.
+
+    Groups per-hop transform metadata and per-space node-level references
+    so downstream consumers (terminal output, JSON writing) can distinguish
+    between transform-level and node-level provenance.
+
+    Attributes:
+        transforms: Per-hop metadata (source/target spaces, provider, refs,
+            notes). One dict per hop in the transformation chain.
+        spaces: Per-space node-level references, deduplicated across the
+            transformation path.
+    """
+
+    def __init__(
+        self,
+        transforms: Sequence[dict[str, Sequence[str]]] | None = None,
+        spaces: Sequence[dict[str, Sequence[str]]] | None = None,
+    ) -> None:
+        """Initialize TransformMetadata.
+
+        Args:
+            transforms: Per-hop metadata dicts.
+            spaces: Per-space node-level reference dicts.
+        """
+        self.transforms = transforms
+        self.spaces = spaces
+
+
 class TransformResult:
     """Result of a transformation, including output path and metadata.
 
     When used without attribute access—printing, f-strings, passing to
     ``os.path.*`` or ``nibabel``—behaves like a :class:`~pathlib.Path`.
-    Access :attr:`references` and :attr:`notes` for transformation metadata.
+    Access :attr:`metadata` for structured provenance, or the backward-
+    compatible :attr:`references` and :attr:`notes` properties for
+    flattened lists.
 
     Attributes:
         path: Output file path, or ``None`` if the transform failed.
-        references: Combined citation strings for all transforms used,
-            or ``None`` if metadata collection was not requested.
-        notes: Caveats and warnings for all transforms used,
-            or ``None`` if metadata collection was not requested.
+        metadata: Structured provenance (per-hop + per-space), or
+            ``None`` if no transform succeeded.
     """
 
     def __init__(
         self,
         output_path: Path | None = None,
-        references: Sequence[str] | None = None,
-        notes: Sequence[str] | None = None,
+        metadata: TransformMetadata | None = None,
     ) -> None:
         """Initialize TransformResult.
 
         Args:
             output_path: Path to the output file, or ``None`` on failure.
-            references: Combined citation strings for all transforms used.
-            notes: Caveats and warnings for all transforms used.
+            metadata: Structured provenance metadata, or ``None``.
         """
         self._output_path = output_path
         self.path = output_path
-        self.references: Sequence[str] | None = references
-        self.notes: Sequence[str] | None = notes
+        self.metadata = metadata
+
+    # --- Backward-compatible computed properties ---
+
+    @property
+    def references(self) -> list[str] | None:
+        """Flattened references from all spaces and hops.
+
+        Space-level references come first, then per-hop references.
+        Returns ``None`` when no metadata is attached.
+        """
+        if self.metadata is None:
+            return None
+        refs: list[str] = []
+        for space in self.metadata.spaces or ():
+            refs.extend(space.get("references") or ())  # type: ignore[arg-type]
+        for hop in self.metadata.transforms or ():
+            refs.extend(hop.get("references") or ())  # type: ignore[arg-type]
+        return refs or None
+
+    @property
+    def notes(self) -> list[str] | None:
+        """Flattened notes from all hops.
+
+        Returns ``None`` when no metadata is attached.
+        """
+        if self.metadata is None:
+            return None
+        notes: list[str] = []
+        for hop in self.metadata.transforms or ():
+            notes.extend(hop.get("notes") or ())  # type: ignore[arg-type]
+        return notes or None
 
     # --- Path-like protocol ---
 
@@ -196,8 +253,7 @@ class TransformResult:
         if isinstance(other, TransformResult):
             return (
                 self._output_path == other._output_path
-                and self.references == other.references
-                and self.notes == other.notes
+                and self.metadata == other.metadata
             )
         return self._output_path == other
 
@@ -221,10 +277,12 @@ class TransformResult:
 
     def __repr__(self) -> str:
         """Return the debug representation."""
+        meta = self.metadata
+        n_hops = len(meta.transforms) if meta and meta.transforms else 0
+        n_spaces = len(meta.spaces) if meta and meta.spaces else 0
         return (
             f"TransformResult(path={self._output_path!r}, "
-            f"refs={len(self.references) if self.references else 0}, "
-            f"notes={len(self.notes) if self.notes else 0})"
+            f"hops={n_hops}, spaces={n_spaces})"
         )
 
     # --- Path method delegation (test compatibility) ---

--- a/src/neuromaps_prime/graph/models.py
+++ b/src/neuromaps_prime/graph/models.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Literal
+from typing import Literal, TypedDict
 
 from pydantic import BaseModel, Field
 
@@ -151,6 +151,36 @@ class Edge(BaseModel):
         return f"\nEdge:\n\tsurfaces=[{surface_str}],\n\tvolumes=[{volume_str}]"
 
 
+class HopMetadataDict(TypedDict, total=False):
+    """Typed dict for per-hop transform metadata.
+
+    Keys:
+        source_space: Source space for this hop.
+        target_space: Target space for this hop.
+        provider: Provider name of the transform.
+        references: Formatted reference strings.
+        notes: Caveat/note strings.
+    """
+
+    source_space: str
+    target_space: str
+    provider: str
+    references: list[str]
+    notes: list[str]
+
+
+class SpaceMetadataDict(TypedDict, total=False):
+    """Typed dict for per-space node metadata.
+
+    Keys:
+        space: Space name.
+        references: Formatted reference strings for the space.
+    """
+
+    space: str
+    references: list[str]
+
+
 class TransformMetadata:
     """Encapsulates provenance metadata for a transform pipeline.
 
@@ -167,8 +197,8 @@ class TransformMetadata:
 
     def __init__(
         self,
-        transforms: Sequence[dict[str, Sequence[str]]] | None = None,
-        spaces: Sequence[dict[str, Sequence[str]]] | None = None,
+        transforms: Sequence[HopMetadataDict] | None = None,
+        spaces: Sequence[SpaceMetadataDict] | None = None,
     ) -> None:
         """Initialize TransformMetadata.
 

--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -14,7 +14,8 @@ from niwrap import workbench
 from pydantic import BaseModel, PrivateAttr
 
 from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'd)
-from neuromaps_prime.graph.models import SurfaceTransform
+from neuromaps_prime.graph.metadata import format_reference
+from neuromaps_prime.graph.models import SurfaceTransform, TransformResult
 from neuromaps_prime.graph.utils import GraphUtils  # noqa: TC001 (pydantic req'd)
 from neuromaps_prime.transforms.surface import (
     label_resample,
@@ -86,7 +87,7 @@ class SurfaceTransformOps(BaseModel):
         *,
         add_edge: bool = True,
         provider: str | None = None,
-    ) -> Path | None:
+    ) -> TransformResult:
         """Resample a metric or label GIFTI from source_space to target_space.
 
         Two-stage process:
@@ -112,8 +113,8 @@ class SurfaceTransformOps(BaseModel):
                 registered provider when ``None``.
 
         Returns:
-            Path to the resampled output file, or ``None`` if the sphere
-            transform could not be resolved.
+            :class:`TransformResult` containing the output path and
+            accumulated references/notes from the transform pipeline.
 
         Raises:
             ValueError: If transformer_type is invalid, or required surface
@@ -140,7 +141,7 @@ class SurfaceTransformOps(BaseModel):
             provider=provider,
         )
         if sphere_transform is None:
-            return None
+            return TransformResult()
 
         target_density = target_density or self.utils.find_highest_density(
             space=target_space
@@ -169,7 +170,7 @@ class SurfaceTransformOps(BaseModel):
 
         match transformer_type:
             case "label":
-                return label_resample(
+                output_path = label_resample(
                     input_file_path=input_file,
                     current_sphere=sphere_transform.fetch(),
                     new_sphere=new_sphere,
@@ -178,7 +179,7 @@ class SurfaceTransformOps(BaseModel):
                     output_file_path=output_file_path,
                 ).label_out
             case "metric":
-                return metric_resample(
+                output_path = metric_resample(
                     input_file_path=input_file,
                     current_sphere=sphere_transform.fetch(),
                     new_sphere=new_sphere,
@@ -186,6 +187,15 @@ class SurfaceTransformOps(BaseModel):
                     area_surfs={"current-area": current_area, "new-area": new_area},
                     output_file_path=output_file_path,
                 ).metric_out
+
+        return TransformResult(
+            output_path=output_path,
+            references=[
+                format_reference(raw) for raw in (sphere_transform.references or ())
+            ]
+            or None,
+            notes=list(sphere_transform.notes) if sphere_transform.notes else None,
+        )
 
     def transform_surface_to_volume(
         self,
@@ -202,7 +212,7 @@ class SurfaceTransformOps(BaseModel):
         *,
         add_edge: bool = True,
         provider: str | None = None,
-    ) -> Path:
+    ) -> TransformResult:
         """Resample from source to target on surface and transform to volume.
 
         Two-stage pipeline:
@@ -229,8 +239,8 @@ class SurfaceTransformOps(BaseModel):
                 registered provider when ``None``.
 
         Returns:
-            Path to the resampled output NIFTI, or ``None`` if the surface
-            transform could not be resolved.
+            :class:`TransformResult` containing the output path and
+            accumulated references/notes from the transform pipeline.
 
         Raises:
             ValueError: If transformer_type is invalid, or required surface
@@ -240,7 +250,7 @@ class SurfaceTransformOps(BaseModel):
         out_surface_fname = (
             "out.label.gii" if transformer_type == "label" else "out.shape.gii"
         )
-        out_surface = self.transform_surface(
+        surface_result = self.transform_surface(
             transformer_type=transformer_type,
             input_file=input_file,
             source_space=source_space,
@@ -253,7 +263,7 @@ class SurfaceTransformOps(BaseModel):
             add_edge=add_edge,
             provider=provider,
         )
-        if out_surface is None:
+        if not surface_result:
             raise FileNotFoundError("Unable to perform transformation to target space.")
 
         target_density = target_density or self.utils.find_highest_density(
@@ -283,8 +293,8 @@ class SurfaceTransformOps(BaseModel):
                 ribbon_surfs = workbench.label_to_volume_mapping_ribbon_constrained(
                     inner_surf=ribbon["white"], outer_surf=ribbon["pial"]
                 )
-                return workbench.label_to_volume_mapping(
-                    label=out_surface,
+                output_path = workbench.label_to_volume_mapping(
+                    label=surface_result.path,
                     surface=target_surface.file_path,
                     volume_space=ref_volume,
                     volume_out=output_file_path,
@@ -294,13 +304,19 @@ class SurfaceTransformOps(BaseModel):
                 ribbon_surfs = workbench.metric_to_volume_mapping_ribbon_constrained(
                     inner_surf=ribbon["white"], outer_surf=ribbon["pial"]
                 )
-                return workbench.metric_to_volume_mapping(
-                    metric=out_surface,
+                output_path = workbench.metric_to_volume_mapping(
+                    metric=surface_result.path,
                     surface=target_surface.file_path,
                     volume_space=ref_volume,
                     volume_out=output_file_path,
                     ribbon_constrained=ribbon_surfs,
                 ).volume_out
+
+        return TransformResult(
+            output_path=output_path,
+            references=surface_result.references,
+            notes=surface_result.notes,
+        )
 
     # ------------------------------------------------------------------ #
     # Sphere transform resolution                                          #
@@ -466,7 +482,7 @@ class SurfaceTransformOps(BaseModel):
             density=density,
             hemisphere=hemisphere,
         )
-        composed_path = self._two_hops(
+        composed_result = self._two_hops(
             source_space=path[hop_idx - 2],
             mid_space=path[hop_idx - 1],
             target_space=next_space,
@@ -476,6 +492,11 @@ class SurfaceTransformOps(BaseModel):
             first_transform=current_transform,
             provider=provider,
         )
+        if composed_result.path is None:
+            raise ValueError(
+                f"Failed to compose transform from '{path[hop_idx - 2]}' to "
+                f"'{next_space}'"
+            )
         new_transform = SurfaceTransform(
             name=f"{source}_to_{next_space}_{density}_{hemisphere}_sphere",
             description=f"Surface transform from '{source}' to '{next_space}'",
@@ -484,9 +505,11 @@ class SurfaceTransformOps(BaseModel):
             density=density,
             hemisphere=hemisphere,
             resource_type="sphere",
-            file_path=composed_path,
+            file_path=composed_result.path,
             weight=float(hop_idx),
             provider=provider or "",
+            references=composed_result.references,
+            notes=composed_result.notes,
         )
         if add_edge:
             self.cache.add_surface_transform(new_transform)
@@ -503,7 +526,7 @@ class SurfaceTransformOps(BaseModel):
         output_file_path: str,
         first_transform: SurfaceTransform | None = None,
         provider: str | None = None,
-    ) -> Path:
+    ) -> TransformResult:
         """Compose two sphere transforms via project-unproject through mid_space.
 
         Args:
@@ -519,7 +542,8 @@ class SurfaceTransformOps(BaseModel):
                 registered provider when ``None``.
 
         Returns:
-            Path to the composed output sphere file.
+            :class:`TransformResult` containing the composed output sphere
+            path and accumulated references/notes from both hops.
 
         Raises:
             ValueError: If any required transform or atlas is missing.
@@ -577,12 +601,31 @@ class SurfaceTransformOps(BaseModel):
             )
         sphere_unproject_from = unproject_transform.fetch()
 
-        return surface_sphere_project_unproject(
+        composed_path = surface_sphere_project_unproject(
             sphere_in=sphere_in,
             sphere_project_to=sphere_project_to,
             sphere_unproject_from=sphere_unproject_from,
             sphere_out=output_file_path,
         ).sphere_out
+
+        # Merge references and notes from both hops, formatting to strings
+        merged_refs = [
+            format_reference(raw)
+            for raw in [
+                *(first_transform.references or ()),
+                *(unproject_transform.references or ()),
+            ]
+        ]
+        merged_notes = [
+            *(first_transform.notes or ()),
+            *(unproject_transform.notes or ()),
+        ]
+
+        return TransformResult(
+            output_path=composed_path,
+            references=merged_refs or None,
+            notes=merged_notes or None,
+        )
 
     # ------------------------------------------------------------------ #
     # Private helpers                                                      #

--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -17,7 +17,6 @@ from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'
 from neuromaps_prime.graph.metadata import format_reference
 from neuromaps_prime.graph.models import (
     HopMetadataDict,
-    SpaceMetadataDict,
     SurfaceTransform,
     TransformMetadata,
     TransformResult,
@@ -220,7 +219,7 @@ class SurfaceTransformOps(BaseModel):
         }
 
         # Collect node-level metadata for all spaces in the path
-        space_meta = self._collect_space_metadata(space_path)
+        space_meta = self.utils.collect_space_metadata(space_path)
 
         return TransformResult(
             output_path=output_path,
@@ -658,7 +657,7 @@ class SurfaceTransformOps(BaseModel):
         }
 
         # Collect node-level metadata for all spaces involved
-        space_meta = self._collect_space_metadata(
+        space_meta = self.utils.collect_space_metadata(
             [source_space, mid_space, target_space]
         )
 
@@ -672,39 +671,6 @@ class SurfaceTransformOps(BaseModel):
     # ------------------------------------------------------------------ #
     # Private helpers                                                      #
     # ------------------------------------------------------------------ #
-
-    def _collect_space_metadata(
-        self, space_path: list[str]
-    ) -> list[SpaceMetadataDict] | None:
-        """Collect deduplicated node-level references for the spaces in *space_path*.
-
-        Walks each space, extracts node data, and formats any attached
-        references.  Shared intermediate spaces only contribute once
-        (deduplicated by space name).
-
-        Args:
-            space_path: Ordered list of space names in the transform path.
-
-        Returns:
-            A list of dicts keyed by ``"space"`` and ``"references"``, or
-            ``None`` when no space has references.
-        """
-        seen: set[str] = set()
-        result: list[SpaceMetadataDict] = []
-
-        for space_name in space_path:
-            if space_name in seen:
-                continue
-            seen.add(space_name)
-
-            node_data = self.utils.get_node_data(space_name)
-            raw_refs = node_data.references or ()
-            formatted = [format_reference(r) for r in raw_refs]
-
-            if formatted:
-                result.append({"space": space_name, "references": formatted})
-
-        return result or None
 
     def _hop_output_path(
         self,

--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -15,7 +15,11 @@ from pydantic import BaseModel, PrivateAttr
 
 from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'd)
 from neuromaps_prime.graph.metadata import format_reference
-from neuromaps_prime.graph.models import SurfaceTransform, TransformResult
+from neuromaps_prime.graph.models import (
+    SurfaceTransform,
+    TransformMetadata,
+    TransformResult,
+)
 from neuromaps_prime.graph.utils import GraphUtils  # noqa: TC001 (pydantic req'd)
 from neuromaps_prime.transforms.surface import (
     label_resample,
@@ -131,12 +135,24 @@ class SurfaceTransformOps(BaseModel):
 
         source_density = source_density or estimate_surface_density(input_file)
 
+        # Find path once — reused for transform resolution and space metadata
+        space_path = self.utils.find_path(
+            source=source_space,
+            target=target_space,
+            edge_type=self.surface_to_surface_key,
+        )
+        if len(space_path) < 2:
+            raise ValueError(
+                f"No valid surface path from '{source_space}' to '{target_space}'"
+            )
+
         sphere_transform = self._resolve_sphere_transform(
             source=source_space,
             target=target_space,
             density=source_density,
             hemisphere=hemisphere,
             output_file_path=output_file_path,
+            space_path=space_path,
             add_edge=add_edge,
             provider=provider,
         )
@@ -188,13 +204,25 @@ class SurfaceTransformOps(BaseModel):
                     output_file_path=output_file_path,
                 ).metric_out
 
+        # Collect per-hop metadata from the resolved transform
+        hop_refs = [
+            format_reference(raw) for raw in (sphere_transform.references or ())
+        ]
+        hop_notes = list(sphere_transform.notes) if sphere_transform.notes else []
+        hop_meta = {
+            "source_space": sphere_transform.source_space,
+            "target_space": sphere_transform.target_space,
+            "provider": sphere_transform.provider,
+            "references": hop_refs,
+            "notes": hop_notes,
+        }
+
+        # Collect node-level metadata for all spaces in the path
+        space_meta = self._collect_space_metadata(space_path)
+
         return TransformResult(
             output_path=output_path,
-            references=[
-                format_reference(raw) for raw in (sphere_transform.references or ())
-            ]
-            or None,
-            notes=list(sphere_transform.notes) if sphere_transform.notes else None,
+            metadata=TransformMetadata(transforms=[hop_meta], spaces=space_meta),
         )
 
     def transform_surface_to_volume(
@@ -312,10 +340,10 @@ class SurfaceTransformOps(BaseModel):
                     ribbon_constrained=ribbon_surfs,
                 ).volume_out
 
+        # Propagate metadata from the surface result, wrapping updated path
         return TransformResult(
             output_path=output_path,
-            references=surface_result.references,
-            notes=surface_result.notes,
+            metadata=surface_result.metadata,
         )
 
     # ------------------------------------------------------------------ #
@@ -329,6 +357,7 @@ class SurfaceTransformOps(BaseModel):
         density: str,
         hemisphere: Literal["left", "right"],
         output_file_path: str,
+        space_path: list[str],
         *,
         add_edge: bool = True,
         provider: str | None = None,
@@ -341,31 +370,27 @@ class SurfaceTransformOps(BaseModel):
             density: Surface mesh density.
             hemisphere: ``'left'`` or ``'right'``.
             output_file_path: Base path used for intermediate output files.
+            space_path: Pre-computed path from source to target.
             add_edge: Whether to register composed transforms.
             provider: Optional provider name. Falls back to the first
                 registered provider when ``None``.
 
         Returns:
-            Resolved :class:`SurfaceTransform`, or ``None`` if no path exists.
+            Resolved :class:`SurfaceTransform`, or ``None`` if no transform
+            exists for the path.
 
         Raises:
-            ValueError: If source and target are the same, or no path exists.
+            ValueError: If source and target are the same.
         """
         if source == target:
             raise ValueError(f"Source and target spaces are the same: '{source}'")
 
-        path = self.utils.find_path(
-            source=source, target=target, edge_type=self.surface_to_surface_key
-        )
-        if len(path) < 2:
-            raise ValueError(f"No valid surface path from '{source}' to '{target}'")
-
         # Throw experimental warnings if following transformations encountered
         self._experimental_warn(
-            paths=path, spaces=self.experimental_xfms, provider=provider
+            paths=space_path, spaces=self.experimental_xfms, provider=provider
         )
 
-        if len(path) == 2:
+        if len(space_path) == 2:
             return self.cache.get_surface_transform(
                 source=source,
                 target=target,
@@ -376,7 +401,7 @@ class SurfaceTransformOps(BaseModel):
             )
 
         return self._compose_multihop(
-            path=path,
+            path=space_path,
             density=density,
             hemisphere=hemisphere,
             output_file_path=output_file_path,
@@ -608,28 +633,76 @@ class SurfaceTransformOps(BaseModel):
             sphere_out=output_file_path,
         ).sphere_out
 
-        # Merge references and notes from both hops, formatting to strings
-        merged_refs = [
-            format_reference(raw)
-            for raw in [
-                *(first_transform.references or ()),
-                *(unproject_transform.references or ()),
-            ]
-        ]
-        merged_notes = [
-            *(first_transform.notes or ()),
-            *(unproject_transform.notes or ()),
-        ]
+        # Build per-hop metadata from both transforms
+        hop1_meta = {
+            "source_space": first_transform.source_space,
+            "target_space": first_transform.target_space,
+            "provider": first_transform.provider,
+            "references": [
+                format_reference(raw) for raw in (first_transform.references or ())
+            ],
+            "notes": list(first_transform.notes) if first_transform.notes else [],
+        }
+        hop2_meta = {
+            "source_space": unproject_transform.source_space,
+            "target_space": unproject_transform.target_space,
+            "provider": unproject_transform.provider,
+            "references": [
+                format_reference(raw) for raw in (unproject_transform.references or ())
+            ],
+            "notes": list(unproject_transform.notes)
+            if unproject_transform.notes
+            else [],
+        }
+
+        # Collect node-level metadata for all spaces involved
+        space_meta = self._collect_space_metadata(
+            [source_space, mid_space, target_space]
+        )
 
         return TransformResult(
             output_path=composed_path,
-            references=merged_refs or None,
-            notes=merged_notes or None,
+            metadata=TransformMetadata(
+                transforms=[hop1_meta, hop2_meta], spaces=space_meta
+            ),
         )
 
     # ------------------------------------------------------------------ #
     # Private helpers                                                      #
     # ------------------------------------------------------------------ #
+
+    def _collect_space_metadata(
+        self, space_path: list[str]
+    ) -> list[dict[str, Sequence[str]]] | None:
+        """Collect deduplicated node-level references for the spaces in *space_path*.
+
+        Walks each space, extracts node data, and formats any attached
+        references.  Shared intermediate spaces only contribute once
+        (deduplicated by space name).
+
+        Args:
+            space_path: Ordered list of space names in the transform path.
+
+        Returns:
+            A list of dicts keyed by ``"space"`` and ``"references"``, or
+            ``None`` when no space has references.
+        """
+        seen: set[str] = set()
+        result: list[dict[str, Sequence[str]]] = []
+
+        for space_name in space_path:
+            if space_name in seen:
+                continue
+            seen.add(space_name)
+
+            node_data = self.utils.get_node_data(space_name)
+            raw_refs = node_data.references or ()
+            formatted = [format_reference(r) for r in raw_refs]
+
+            if formatted:
+                result.append({"space": space_name, "references": formatted})
+
+        return result or None
 
     def _hop_output_path(
         self,

--- a/src/neuromaps_prime/graph/transforms/surface.py
+++ b/src/neuromaps_prime/graph/transforms/surface.py
@@ -16,6 +16,8 @@ from pydantic import BaseModel, PrivateAttr
 from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'd)
 from neuromaps_prime.graph.metadata import format_reference
 from neuromaps_prime.graph.models import (
+    HopMetadataDict,
+    SpaceMetadataDict,
     SurfaceTransform,
     TransformMetadata,
     TransformResult,
@@ -209,7 +211,7 @@ class SurfaceTransformOps(BaseModel):
             format_reference(raw) for raw in (sphere_transform.references or ())
         ]
         hop_notes = list(sphere_transform.notes) if sphere_transform.notes else []
-        hop_meta = {
+        hop_meta: HopMetadataDict = {
             "source_space": sphere_transform.source_space,
             "target_space": sphere_transform.target_space,
             "provider": sphere_transform.provider,
@@ -634,7 +636,7 @@ class SurfaceTransformOps(BaseModel):
         ).sphere_out
 
         # Build per-hop metadata from both transforms
-        hop1_meta = {
+        hop1_meta: HopMetadataDict = {
             "source_space": first_transform.source_space,
             "target_space": first_transform.target_space,
             "provider": first_transform.provider,
@@ -643,7 +645,7 @@ class SurfaceTransformOps(BaseModel):
             ],
             "notes": list(first_transform.notes) if first_transform.notes else [],
         }
-        hop2_meta = {
+        hop2_meta: HopMetadataDict = {
             "source_space": unproject_transform.source_space,
             "target_space": unproject_transform.target_space,
             "provider": unproject_transform.provider,
@@ -673,7 +675,7 @@ class SurfaceTransformOps(BaseModel):
 
     def _collect_space_metadata(
         self, space_path: list[str]
-    ) -> list[dict[str, Sequence[str]]] | None:
+    ) -> list[SpaceMetadataDict] | None:
         """Collect deduplicated node-level references for the spaces in *space_path*.
 
         Walks each space, extracts node data, and formats any attached
@@ -688,7 +690,7 @@ class SurfaceTransformOps(BaseModel):
             ``None`` when no space has references.
         """
         seen: set[str] = set()
-        result: list[dict[str, Sequence[str]]] = []
+        result: list[SpaceMetadataDict] = []
 
         for space_name in space_path:
             if space_name in seen:

--- a/src/neuromaps_prime/graph/transforms/volume.py
+++ b/src/neuromaps_prime/graph/transforms/volume.py
@@ -13,7 +13,12 @@ from pydantic import BaseModel
 
 from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'd)
 from neuromaps_prime.graph.metadata import format_reference
-from neuromaps_prime.graph.models import TransformMetadata, TransformResult
+from neuromaps_prime.graph.models import (
+    HopMetadataDict,
+    SpaceMetadataDict,
+    TransformMetadata,
+    TransformResult,
+)
 from neuromaps_prime.graph.transforms.surface import (
     SurfaceTransformOps,  # noqa: TC001 (pydantic req'd)
 )
@@ -22,7 +27,6 @@ from neuromaps_prime.transforms.utils import validate_volume_file
 from neuromaps_prime.transforms.volume import surface_project, vol_to_vol
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from pathlib import Path
 
 
@@ -125,7 +129,7 @@ class VolumeTransformOps(BaseModel):
         )
 
         # Collect per-hop metadata from the resolved transform
-        hop_meta = {
+        hop_meta: HopMetadataDict = {
             "source_space": transform.source_space,
             "target_space": transform.target_space,
             "provider": transform.provider,
@@ -236,7 +240,7 @@ class VolumeTransformOps(BaseModel):
 
     def _collect_space_metadata(
         self, space_path: list[str]
-    ) -> list[dict[str, Sequence[str]]] | None:
+    ) -> list[SpaceMetadataDict] | None:
         """Collect deduplicated node-level references for the spaces in *space_path*.
 
         Args:
@@ -247,7 +251,7 @@ class VolumeTransformOps(BaseModel):
             ``None`` when no space has references.
         """
         seen: set[str] = set()
-        result: list[dict[str, Sequence[str]]] = []
+        result: list[SpaceMetadataDict] = []
 
         for space_name in space_path:
             if space_name in seen:

--- a/src/neuromaps_prime/graph/transforms/volume.py
+++ b/src/neuromaps_prime/graph/transforms/volume.py
@@ -15,7 +15,6 @@ from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'
 from neuromaps_prime.graph.metadata import format_reference
 from neuromaps_prime.graph.models import (
     HopMetadataDict,
-    SpaceMetadataDict,
     TransformMetadata,
     TransformResult,
 )
@@ -140,7 +139,7 @@ class VolumeTransformOps(BaseModel):
         }
 
         # Collect node-level metadata for source and target spaces
-        space_meta = self._collect_space_metadata([source_space, target_space])
+        space_meta = self.utils.collect_space_metadata([source_space, target_space])
 
         return TransformResult(
             output_path=output_path,
@@ -237,35 +236,6 @@ class VolumeTransformOps(BaseModel):
     # ------------------------------------------------------------------ #
     # Private helpers                                                      #
     # ------------------------------------------------------------------ #
-
-    def _collect_space_metadata(
-        self, space_path: list[str]
-    ) -> list[SpaceMetadataDict] | None:
-        """Collect deduplicated node-level references for the spaces in *space_path*.
-
-        Args:
-            space_path: Ordered list of space names in the transform path.
-
-        Returns:
-            A list of dicts keyed by ``"space"`` and ``"references"``, or
-            ``None`` when no space has references.
-        """
-        seen: set[str] = set()
-        result: list[SpaceMetadataDict] = []
-
-        for space_name in space_path:
-            if space_name in seen:
-                continue
-            seen.add(space_name)
-
-            node_data = self.utils.get_node_data(space_name)
-            raw_refs = node_data.references or ()
-            formatted = [format_reference(r) for r in raw_refs]
-
-            if formatted:
-                result.append({"space": space_name, "references": formatted})
-
-        return result or None
 
     def _project_volume_to_surface(
         self,

--- a/src/neuromaps_prime/graph/transforms/volume.py
+++ b/src/neuromaps_prime/graph/transforms/volume.py
@@ -12,6 +12,8 @@ from niwrap import workbench
 from pydantic import BaseModel
 
 from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'd)
+from neuromaps_prime.graph.metadata import format_reference
+from neuromaps_prime.graph.models import TransformResult
 from neuromaps_prime.graph.transforms.surface import (
     SurfaceTransformOps,  # noqa: TC001 (pydantic req'd)
 )
@@ -63,7 +65,7 @@ class VolumeTransformOps(BaseModel):
         atlas_resource_type: str = "T1w",
         *,
         provider: str | None = None,
-    ) -> Path:
+    ) -> TransformResult:
         """Warp a volume image from source_space to target_space.
 
         Args:
@@ -81,7 +83,8 @@ class VolumeTransformOps(BaseModel):
                 registered provider when ``None``.
 
         Returns:
-            Path to the warped output volume.
+            :class:`TransformResult` containing the output path and
+            accumulated references/notes from the transform pipeline.
 
         Raises:
             FileNotFoundError: If input_file does not exist.
@@ -112,12 +115,19 @@ class VolumeTransformOps(BaseModel):
                 f"(resolution='{resolution}', resource_type='{atlas_resource_type}')"
             )
 
-        return vol_to_vol(
+        output_path = vol_to_vol(
             source=input_file,
             target=target_atlas.fetch(),
             out_fpath=output_file_path,
             interp=interp,
             interp_params=interp_params,
+        )
+
+        return TransformResult(
+            output_path=output_path,
+            references=[format_reference(raw) for raw in (transform.references or ())]
+            or None,
+            notes=list(transform.notes) if transform.notes else None,
         )
 
     # ------------------------------------------------------------------ #
@@ -138,7 +148,7 @@ class VolumeTransformOps(BaseModel):
         *,
         add_edge: bool = True,
         provider: str | None = None,
-    ) -> Path | None:
+    ) -> TransformResult:
         """Project a volume into surface space then resample to target_space.
 
         Two-stage pipeline:
@@ -163,8 +173,8 @@ class VolumeTransformOps(BaseModel):
                 registered provider when ``None``.
 
         Returns:
-            Path to the resampled output GIFTI, or ``None`` if the surface
-            transform could not be resolved.
+            :class:`TransformResult` containing the output path and
+            accumulated references/notes from the transform pipeline.
 
         Raises:
             FileNotFoundError: If input_file does not exist.

--- a/src/neuromaps_prime/graph/transforms/volume.py
+++ b/src/neuromaps_prime/graph/transforms/volume.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'd)
 from neuromaps_prime.graph.metadata import format_reference
-from neuromaps_prime.graph.models import TransformResult
+from neuromaps_prime.graph.models import TransformMetadata, TransformResult
 from neuromaps_prime.graph.transforms.surface import (
     SurfaceTransformOps,  # noqa: TC001 (pydantic req'd)
 )
@@ -22,6 +22,7 @@ from neuromaps_prime.transforms.utils import validate_volume_file
 from neuromaps_prime.transforms.volume import surface_project, vol_to_vol
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
 
@@ -123,11 +124,23 @@ class VolumeTransformOps(BaseModel):
             interp_params=interp_params,
         )
 
+        # Collect per-hop metadata from the resolved transform
+        hop_meta = {
+            "source_space": transform.source_space,
+            "target_space": transform.target_space,
+            "provider": transform.provider,
+            "references": [
+                format_reference(raw) for raw in (transform.references or ())
+            ],
+            "notes": list(transform.notes) if transform.notes else [],
+        }
+
+        # Collect node-level metadata for source and target spaces
+        space_meta = self._collect_space_metadata([source_space, target_space])
+
         return TransformResult(
             output_path=output_path,
-            references=[format_reference(raw) for raw in (transform.references or ())]
-            or None,
-            notes=list(transform.notes) if transform.notes else None,
+            metadata=TransformMetadata(transforms=[hop_meta], spaces=space_meta),
         )
 
     # ------------------------------------------------------------------ #
@@ -220,6 +233,35 @@ class VolumeTransformOps(BaseModel):
     # ------------------------------------------------------------------ #
     # Private helpers                                                      #
     # ------------------------------------------------------------------ #
+
+    def _collect_space_metadata(
+        self, space_path: list[str]
+    ) -> list[dict[str, Sequence[str]]] | None:
+        """Collect deduplicated node-level references for the spaces in *space_path*.
+
+        Args:
+            space_path: Ordered list of space names in the transform path.
+
+        Returns:
+            A list of dicts keyed by ``"space"`` and ``"references"``, or
+            ``None`` when no space has references.
+        """
+        seen: set[str] = set()
+        result: list[dict[str, Sequence[str]]] = []
+
+        for space_name in space_path:
+            if space_name in seen:
+                continue
+            seen.add(space_name)
+
+            node_data = self.utils.get_node_data(space_name)
+            raw_refs = node_data.references or ()
+            formatted = [format_reference(r) for r in raw_refs]
+
+            if formatted:
+                result.append({"space": space_name, "references": formatted})
+
+        return result or None
 
     def _project_volume_to_surface(
         self,

--- a/src/neuromaps_prime/graph/utils.py
+++ b/src/neuromaps_prime/graph/utils.py
@@ -6,13 +6,17 @@ utilities that operate on the NetworkX graph structure.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 from pydantic import BaseModel
 
 from neuromaps_prime.graph.cache import GraphCache  # noqa: TC001 (pydantic req'd)
+from neuromaps_prime.graph.metadata import format_reference
 from neuromaps_prime.transforms.utils import _get_density_key
+
+if TYPE_CHECKING:
+    from neuromaps_prime.graph.models import SpaceMetadataDict
 
 
 class GraphUtils(BaseModel):
@@ -171,6 +175,39 @@ class GraphUtils(BaseModel):
                 f"Availble nodes: {sorted(self.graph.nodes)}"
             )
             raise ValueError(msg) from e
+
+    def collect_space_metadata(
+        self, space_path: list[str]
+    ) -> list[SpaceMetadataDict] | None:
+        """Collect deduplicated node-level references for the spaces in *space_path*.
+
+        Walks each space, extracts node data, and formats any attached
+        references.  Shared intermediate spaces only contribute once
+        (deduplicated by space name).
+
+        Args:
+            space_path: Ordered list of space names in the transform path.
+
+        Returns:
+            A list of dicts keyed by ``"space"`` and ``"references"``, or
+            ``None`` when no space has references.
+        """
+        seen: set[str] = set()
+        result: list[SpaceMetadataDict] = []
+
+        for space_name in space_path:
+            if space_name in seen:
+                continue
+            seen.add(space_name)
+
+            node_data = self.get_node_data(space_name)
+            raw_refs = node_data.references or ()
+            formatted = [format_reference(r) for r in raw_refs]
+
+            if formatted:
+                result.append({"space": space_name, "references": formatted})
+
+        return result or None
 
     def get_graph_info(self) -> dict[str, int]:
         """Return a summary of the graph structure.

--- a/tests/unit/graph/conftest.py
+++ b/tests/unit/graph/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures for transformer unit tests.
+"""Shared fixtures for graph unit tests.
 
 Provides factory fixtures that construct MagicMock instances with the
 standard transform attributes (source_space, target_space, provider,

--- a/tests/unit/graph/test_metadata.py
+++ b/tests/unit/graph/test_metadata.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from neuromaps_prime.graph.metadata import format_reference
+from io import StringIO
+from typing import TYPE_CHECKING
+
+from neuromaps_prime.graph.metadata import format_reference, print_metadata_summary
+from neuromaps_prime.graph.models import TransformMetadata, TransformResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestFormatReference:
@@ -46,3 +53,140 @@ class TestFormatReference:
         """Dict with empty-string values omits those parts."""
         result = format_reference({"citation": "", "doi": "", "url": ""})
         assert result == ""
+
+
+class TestPrintMetadataSummary:
+    """Tests for the print_metadata_summary function."""
+
+    def test_prints_nothing_when_result_is_none(self) -> None:
+        """Does nothing when result is None/falsy."""
+        buf = StringIO()
+        print_metadata_summary(TransformResult(), file=buf)
+        assert buf.getvalue() == ""
+
+    def test_prints_nothing_when_metadata_is_none(self, tmp_path: Path) -> None:
+        """Does nothing when metadata is None."""
+        buf = StringIO()
+        result = TransformResult(output_path=tmp_path / "out.nii")
+        print_metadata_summary(result, file=buf)
+        assert buf.getvalue() == ""
+
+    def test_prints_spaces_and_hops(self, tmp_path: Path) -> None:
+        """Prints grouped spaces and per-hop metadata."""
+        meta = TransformMetadata(
+            transforms=[
+                {
+                    "source_space": "A",
+                    "target_space": "B",
+                    "provider": "RheMap",
+                    "references": ["Smith et al. 2020"],
+                    "notes": ["Experimental alignment"],
+                },
+            ],
+            spaces=[
+                {"space": "A", "references": ["Space A citation"]},
+                {"space": "B", "references": ["Space B citation"]},
+            ],
+        )
+        result = TransformResult(output_path=tmp_path / "out.nii", metadata=meta)
+        buf = StringIO()
+        print_metadata_summary(result, file=buf)
+        output = buf.getvalue()
+
+        # Check header
+        assert "=== Transformation: A -> B ===" in output
+        # Check spaces section
+        assert "--- Spaces ---" in output
+        assert "A:" in output
+        assert "Ref: Space A citation" in output
+        assert "B:" in output
+        assert "Ref: Space B citation" in output
+        # Check hop section
+        assert "--- A -> B [RheMap] ---" in output
+        assert "References:" in output
+        assert "- Smith et al. 2020" in output
+        assert "Caveats:" in output
+        assert "- Experimental alignment" in output
+        # Check footer
+        assert "=== End ===" in output
+
+    def test_prints_multiple_hops(self, tmp_path: Path) -> None:
+        """Prints multiple hops sequentially."""
+        meta = TransformMetadata(
+            transforms=[
+                {
+                    "source_space": "A",
+                    "target_space": "B",
+                    "provider": "RheMap",
+                    "references": ["Ref 1"],
+                    "notes": [],
+                },
+                {
+                    "source_space": "B",
+                    "target_space": "C",
+                    "provider": "CIVET",
+                    "references": ["Ref 2"],
+                    "notes": ["Note 2"],
+                },
+            ],
+            spaces=[
+                {"space": "A", "references": ["A ref"]},
+                {"space": "B", "references": ["B ref"]},
+                {"space": "C", "references": ["C ref"]},
+            ],
+        )
+        result = TransformResult(output_path=tmp_path / "out.nii", metadata=meta)
+        buf = StringIO()
+        print_metadata_summary(result, file=buf)
+        output = buf.getvalue()
+
+        # Check path shows all spaces
+        assert "A -> B -> C" in output
+        # Check both hops appear
+        assert "--- A -> B [RheMap] ---" in output
+        assert "--- B -> C [CIVET] ---" in output
+        assert "- Ref 1" in output
+        assert "- Ref 2" in output
+        assert "- Note 2" in output
+
+    def test_skips_sections_when_empty(self, tmp_path: Path) -> None:
+        """Omits spaces and caveats sections when their lists are empty."""
+        meta = TransformMetadata(
+            transforms=[
+                {
+                    "source_space": "X",
+                    "target_space": "Y",
+                    "provider": "Test",
+                    "references": ["Only ref"],
+                    "notes": [],
+                },
+            ],
+            spaces=[],
+        )
+        result = TransformResult(output_path=tmp_path / "out.nii", metadata=meta)
+        buf = StringIO()
+        print_metadata_summary(result, file=buf)
+        output = buf.getvalue()
+
+        assert "--- Spaces ---" not in output
+        assert "Caveats:" not in output
+        assert "- Only ref" in output
+
+    def test_accepts_custom_file_argument(self, tmp_path: Path) -> None:
+        """Writes to the provided file-like object."""
+        meta = TransformMetadata(
+            transforms=[
+                {
+                    "source_space": "A",
+                    "target_space": "B",
+                    "provider": "Test",
+                    "references": [],
+                    "notes": [],
+                },
+            ],
+            spaces=[],
+        )
+        result = TransformResult(output_path=tmp_path / "out.nii", metadata=meta)
+        buf = StringIO()
+        print_metadata_summary(result, file=buf)
+        assert len(buf.getvalue()) > 0

--- a/tests/unit/graph/test_metadata.py
+++ b/tests/unit/graph/test_metadata.py
@@ -1,0 +1,48 @@
+"""Tests for metadata formatting helpers."""
+
+from __future__ import annotations
+
+from neuromaps_prime.graph.metadata import format_reference
+
+
+class TestFormatReference:
+    """Tests for the format_reference helper."""
+
+    def test_string_reference_passthrough(self) -> None:
+        """Plain string references are returned as-is."""
+        assert format_reference("Smith et al. 2020") == "Smith et al. 2020"
+
+    def test_dict_with_citation_only(self) -> None:
+        """Dict with only citation key returns just the citation."""
+        result = format_reference({"citation": "Smith et al. 2020"})
+        assert result == "Smith et al. 2020"
+
+    def test_dict_with_citation_and_doi(self) -> None:
+        """Dict with citation and DOI is joined with pipe."""
+        result = format_reference(
+            {"citation": "Smith et al. 2020", "doi": "10.1234/abc"}
+        )
+        assert result == "Smith et al. 2020 | DOI: 10.1234/abc"
+
+    def test_dict_with_all_keys(self) -> None:
+        """Dict with all three keys produces three pipe-separated parts."""
+        result = format_reference(
+            {
+                "citation": "Smith et al. 2020",
+                "doi": "10.1234/abc",
+                "url": "https://example.org",
+            }
+        )
+        assert (
+            result == "Smith et al. 2020 | DOI: 10.1234/abc | URL: https://example.org"
+        )
+
+    def test_dict_with_missing_citation(self) -> None:
+        """Dict without citation key still formats DOI and URL."""
+        result = format_reference({"doi": "10.1234/abc", "url": "https://example.org"})
+        assert result == "DOI: 10.1234/abc | URL: https://example.org"
+
+    def test_dict_with_empty_values(self) -> None:
+        """Dict with empty-string values omits those parts."""
+        result = format_reference({"citation": "", "doi": "", "url": ""})
+        assert result == ""

--- a/tests/unit/graph/test_model.py
+++ b/tests/unit/graph/test_model.py
@@ -321,3 +321,151 @@ class TestEdge:
         edge = models.Edge()
         assert len(edge.surface_transforms) == 0
         assert len(edge.volume_transforms) == 0
+
+
+class TestTransformMetadata:
+    """Tests for TransformMetadata class."""
+
+    def test_init_defaults_to_none(self) -> None:
+        """TransformMetadata defaults to None for both attributes."""
+        meta = models.TransformMetadata()
+        assert meta.transforms is None
+        assert meta.spaces is None
+
+    def test_init_with_transforms(self) -> None:
+        """TransformMetadata stores transforms list."""
+        transforms = [
+            {
+                "source_space": "A",
+                "target_space": "B",
+                "provider": "RheMap",
+                "references": ["Smith et al. 2020"],
+                "notes": ["Note 1"],
+            }
+        ]
+        meta = models.TransformMetadata(transforms=transforms)
+        assert meta.transforms == transforms
+        assert meta.spaces is None
+
+    def test_init_with_spaces(self) -> None:
+        """TransformMetadata stores spaces list."""
+        spaces = [{"space": "A", "references": ["Space A citation"]}]
+        meta = models.TransformMetadata(spaces=spaces)
+        assert meta.spaces == spaces
+        assert meta.transforms is None
+
+    def test_init_with_both(self) -> None:
+        """TransformMetadata stores both transforms and spaces."""
+        transforms = [
+            {
+                "source_space": "A",
+                "target_space": "B",
+                "provider": "RheMap",
+                "references": ["Smith et al. 2020"],
+                "notes": ["Note 1"],
+            }
+        ]
+        spaces = [{"space": "A", "references": ["Space A citation"]}]
+        meta = models.TransformMetadata(transforms=transforms, spaces=spaces)
+        assert meta.transforms == transforms
+        assert meta.spaces == spaces
+
+
+class TestTransformResult:
+    """Tests for TransformResult class."""
+
+    def test_init_defaults(self) -> None:
+        """TransformResult defaults to None for path and metadata."""
+        result = models.TransformResult()
+        assert result.path is None
+        assert result.metadata is None
+
+    def test_backward_compat_references_empty(self) -> None:
+        """References property returns None when no metadata."""
+        result = models.TransformResult()
+        assert result.references is None
+
+    def test_backward_compat_notes_empty(self) -> None:
+        """Notes property returns None when no metadata."""
+        result = models.TransformResult()
+        assert result.notes is None
+
+    def test_backward_compat_references_flattens_spaces_and_hops(
+        self, tmp_path: Path
+    ) -> None:
+        """References property flattens space and hop references."""
+        meta = models.TransformMetadata(
+            transforms=[
+                {"references": ["Hop ref 1"]},
+                {"references": ["Hop ref 2"]},
+            ],
+            spaces=[
+                {"references": ["Space ref 1"]},
+            ],
+        )
+        result = models.TransformResult(output_path=tmp_path / "out.nii", metadata=meta)
+        assert result.references == ["Space ref 1", "Hop ref 1", "Hop ref 2"]
+
+    def test_backward_compat_notes_flattens_hops(self, tmp_path: Path) -> None:
+        """Notes property flattens hop notes."""
+        meta = models.TransformMetadata(
+            transforms=[
+                {"notes": ["Note 1"]},
+                {"notes": ["Note 2"]},
+            ],
+        )
+        result = models.TransformResult(output_path=tmp_path / "out.nii", metadata=meta)
+        assert result.notes == ["Note 1", "Note 2"]
+
+    def test_backward_compat_references_returns_none_when_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """References returns None when all lists are empty."""
+        meta = models.TransformMetadata(transforms=[{"references": []}], spaces=[])
+        result = models.TransformResult(output_path=tmp_path / "out.nii", metadata=meta)
+        assert result.references is None
+
+    def test_backward_compat_notes_returns_none_when_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """Notes returns None when all lists are empty."""
+        meta = models.TransformMetadata(transforms=[{"notes": []}])
+        result = models.TransformResult(output_path=tmp_path / "out.nii", metadata=meta)
+        assert result.notes is None
+
+    def test_repr_shows_hop_and_space_counts(self, tmp_path: Path) -> None:
+        """__repr__ shows hop count and space count."""
+        meta = models.TransformMetadata(
+            transforms=[{"references": []}, {"references": []}],
+            spaces=[{"references": []}, {"references": []}, {"references": []}],
+        )
+        result = models.TransformResult(output_path=tmp_path / "out.nii", metadata=meta)
+        r = repr(result)
+        assert "hops=2" in r
+        assert "spaces=3" in r
+
+    def test_repr_shows_zero_when_no_metadata(self, tmp_path: Path) -> None:
+        """__repr__ shows zero counts when no metadata."""
+        result = models.TransformResult(output_path=tmp_path / "out.nii")
+        r = repr(result)
+        assert "hops=0" in r
+        assert "spaces=0" in r
+
+    def test_eq_with_transform_result(self, tmp_path: Path) -> None:
+        """Equality compares path and metadata."""
+        meta = models.TransformMetadata(transforms=[{"references": ["Ref"]}], spaces=[])
+        result_a = models.TransformResult(
+            output_path=tmp_path / "out.nii", metadata=meta
+        )
+        result_b = models.TransformResult(
+            output_path=tmp_path / "out.nii", metadata=meta
+        )
+        result_c = models.TransformResult(output_path=tmp_path / "out.nii")
+        assert result_a == result_b
+        assert result_a != result_c
+
+    def test_eq_with_path(self, tmp_path: Path) -> None:
+        """Equality with Path only compares output path."""
+        p = tmp_path / "out.nii"
+        result = models.TransformResult(output_path=p)
+        assert result == p

--- a/tests/unit/graph/test_model.py
+++ b/tests/unit/graph/test_model.py
@@ -469,3 +469,159 @@ class TestTransformResult:
         p = tmp_path / "out.nii"
         result = models.TransformResult(output_path=p)
         assert result == p
+
+
+class TestTransformResultSaveMetadata:
+    """Tests for TransformResult.save_metadata."""
+
+    def _make_result(self, tmp_path: Path) -> models.TransformResult:
+        """Create a TransformResult with sample metadata."""
+        meta = models.TransformMetadata(
+            transforms=[
+                {
+                    "source_space": "A",
+                    "target_space": "B",
+                    "provider": "RheMap",
+                    "references": ["Smith et al. 2020"],
+                    "notes": ["Test note"],
+                }
+            ],
+            spaces=[{"space": "A", "references": ["Space A citation"]}],
+        )
+        return models.TransformResult(output_path=tmp_path / "out.gii", metadata=meta)
+
+    def test_raises_value_error_when_path_is_none(self) -> None:
+        """save_metadata raises ValueError when output path is None."""
+        result = models.TransformResult()
+        with pytest.raises(ValueError, match="output path is None"):
+            result.save_metadata()
+
+    def test_raises_not_implemented_for_unsupported_extension(
+        self, tmp_path: Path
+    ) -> None:
+        """save_metadata raises NotImplementedError for unsupported extensions."""
+        result = self._make_result(tmp_path)
+        with pytest.raises(NotImplementedError, match="Unsupported file extension"):
+            result.save_metadata(metadata_path=tmp_path / "out.txt")
+
+    def test_default_creates_md_file(self, tmp_path: Path) -> None:
+        """By default, save_metadata creates a .md file."""
+        result = self._make_result(tmp_path)
+        meta_path = result.save_metadata()
+        assert meta_path == tmp_path / "out.gii.md"
+        assert meta_path.exists()
+
+    def test_md_contains_header_and_sections(self, tmp_path: Path) -> None:
+        """Markdown output contains transformation header, spaces, and transforms."""
+        result = self._make_result(tmp_path)
+        result.save_metadata()
+        content = (tmp_path / "out.gii.md").read_text()
+        assert "# Transformation:" in content
+        assert "A -> B" in content
+        assert "## Spaces" in content
+        assert "## Transforms" in content
+        assert "**References:**" in content
+        assert "**Caveats:**" in content
+
+    def test_md_contains_space_references(self, tmp_path: Path) -> None:
+        """Markdown output includes space-level references."""
+        result = self._make_result(tmp_path)
+        result.save_metadata()
+        content = (tmp_path / "out.gii.md").read_text()
+        assert "Space A citation" in content
+
+    def test_md_contains_hop_references_and_notes(self, tmp_path: Path) -> None:
+        """Markdown output includes hop-level references and notes."""
+        result = self._make_result(tmp_path)
+        result.save_metadata()
+        content = (tmp_path / "out.gii.md").read_text()
+        assert "Smith et al. 2020" in content
+        assert "Test note" in content
+
+    def test_md_contains_timestamp(self, tmp_path: Path) -> None:
+        """Markdown output includes a timestamp footer."""
+        result = self._make_result(tmp_path)
+        result.save_metadata()
+        content = (tmp_path / "out.gii.md").read_text()
+        assert "Generated at" in content
+
+    def test_json_file_creation(self, tmp_path: Path) -> None:
+        """save_metadata creates a .json file when extension is .json."""
+        result = self._make_result(tmp_path)
+        meta_path = result.save_metadata(metadata_path=tmp_path / "out.json")
+        assert meta_path == tmp_path / "out.json"
+        assert meta_path.exists()
+
+    def test_json_contains_expected_keys(self, tmp_path: Path) -> None:
+        """JSON output contains expected top-level keys."""
+        import json
+
+        result = self._make_result(tmp_path)
+        result.save_metadata(metadata_path=tmp_path / "out.json")
+        data = json.loads((tmp_path / "out.json").read_text())
+        assert "output_file" in data
+        assert "transform_path" in data
+        assert "spaces" in data
+        assert "transforms" in data
+        assert "timestamp" in data
+
+    def test_json_transform_path(self, tmp_path: Path) -> None:
+        """JSON transform_path is derived from hop metadata."""
+        import json
+
+        result = self._make_result(tmp_path)
+        result.save_metadata(metadata_path=tmp_path / "out.json")
+        data = json.loads((tmp_path / "out.json").read_text())
+        assert data["transform_path"] == ["A", "B"]
+
+    def test_json_spaces_content(self, tmp_path: Path) -> None:
+        """JSON spaces contain space-level references."""
+        import json
+
+        result = self._make_result(tmp_path)
+        result.save_metadata(metadata_path=tmp_path / "out.json")
+        data = json.loads((tmp_path / "out.json").read_text())
+        assert data["spaces"][0]["space"] == "A"
+        assert "Space A citation" in data["spaces"][0]["references"]
+
+    def test_json_transforms_content(self, tmp_path: Path) -> None:
+        """JSON transforms contain hop-level references and notes."""
+        import json
+
+        result = self._make_result(tmp_path)
+        result.save_metadata(metadata_path=tmp_path / "out.json")
+        data = json.loads((tmp_path / "out.json").read_text())
+        hop = data["transforms"][0]
+        assert hop["source_space"] == "A"
+        assert hop["target_space"] == "B"
+        assert hop["provider"] == "RheMap"
+        assert "Smith et al. 2020" in hop["references"]
+        assert "Test note" in hop["notes"]
+
+    def test_json_timestamp_is_iso_format(self, tmp_path: Path) -> None:
+        """JSON timestamp is ISO 8601 format."""
+        import json
+        from datetime import datetime
+
+        result = self._make_result(tmp_path)
+        result.save_metadata(metadata_path=tmp_path / "out.json")
+        data = json.loads((tmp_path / "out.json").read_text())
+        ts = data["timestamp"]
+        parsed = datetime.fromisoformat(ts)
+        assert parsed is not None
+
+    def test_returns_path_to_written_file(self, tmp_path: Path) -> None:
+        """save_metadata returns the path to the written file."""
+        result = self._make_result(tmp_path)
+        meta_path = result.save_metadata()
+        assert meta_path.exists()
+        assert meta_path.suffix == ".md"
+
+    def test_no_metadata_produces_minimal_output(self, tmp_path: Path) -> None:
+        """save_metadata with no metadata produces minimal output."""
+        result = models.TransformResult(output_path=tmp_path / "out.gii")
+        result.save_metadata()
+        content = (tmp_path / "out.gii.md").read_text()
+        assert "# Transformation:" in content
+        assert "## Spaces" not in content
+        assert "## Transforms" not in content

--- a/tests/unit/graph/test_model.py
+++ b/tests/unit/graph/test_model.py
@@ -453,12 +453,17 @@ class TestTransformResult:
 
     def test_eq_with_transform_result(self, tmp_path: Path) -> None:
         """Equality compares path and metadata."""
-        meta = models.TransformMetadata(transforms=[{"references": ["Ref"]}], spaces=[])
+        meta_a = models.TransformMetadata(
+            transforms=[{"references": ["Ref"]}], spaces=[]
+        )
+        meta_b = models.TransformMetadata(
+            transforms=[{"references": ["Ref"]}], spaces=[]
+        )
         result_a = models.TransformResult(
-            output_path=tmp_path / "out.nii", metadata=meta
+            output_path=tmp_path / "out.nii", metadata=meta_a
         )
         result_b = models.TransformResult(
-            output_path=tmp_path / "out.nii", metadata=meta
+            output_path=tmp_path / "out.nii", metadata=meta_b
         )
         result_c = models.TransformResult(output_path=tmp_path / "out.nii")
         assert result_a == result_b
@@ -469,6 +474,22 @@ class TestTransformResult:
         p = tmp_path / "out.nii"
         result = models.TransformResult(output_path=p)
         assert result == p
+
+    def test_fspath_delegates_to_path(self, tmp_path: Path) -> None:
+        """os.fspath() returns the output path string."""
+        import os
+
+        p = tmp_path / "out.gii"
+        result = models.TransformResult(output_path=p)
+        assert os.fspath(result) == str(p)
+
+    def test_fspath_raises_when_none(self) -> None:
+        """os.fspath() raises TypeError when output path is None."""
+        import os
+
+        result = models.TransformResult()
+        with pytest.raises(TypeError, match="Cannot get filesystem path"):
+            os.fspath(result)
 
 
 class TestTransformResultSaveMetadata:

--- a/tests/unit/graph/test_ops.py
+++ b/tests/unit/graph/test_ops.py
@@ -42,6 +42,8 @@ class TestTwoHops:
             spec=models.SurfaceTransform,
             fetch=MagicMock(return_value=sphere_project_to),
             provider="RheMap",
+            references=None,
+            notes=None,
         )
         mid_atlas = MagicMock(
             spec=models.SurfaceAtlas,
@@ -51,6 +53,8 @@ class TestTwoHops:
             spec=models.SurfaceTransform,
             fetch=MagicMock(return_value=sphere_unproject_from),
             provider="RheMap",
+            references=None,
+            notes=None,
         )
         return {"first": first, "mid_atlas": mid_atlas, "second": second}
 
@@ -87,7 +91,7 @@ class TestTwoHops:
                 provider="RheMap",
             )
 
-        assert result == expected_out
+        assert result.path == expected_out
         assert not any("falling back" in r.message for r in caplog.records)
 
     def test_missing_first_transform_raises(
@@ -183,7 +187,12 @@ class TestTwoHops:
     ) -> None:
         """Warning emitted when first hop uses a different provider than requested."""
         expected_out = tmp_path / "out.surf.gii"
-        first = MagicMock(spec=models.SurfaceTransform, provider="CIVET")
+        first = MagicMock(
+            spec=models.SurfaceTransform,
+            provider="CIVET",
+            references=None,
+            notes=None,
+        )
         first.fetch.return_value = tmp_path / "sphere_in.surf.gii"
 
         ops.cache.get_surface_transform.return_value = mock_transforms["second"]
@@ -227,7 +236,12 @@ class TestTwoHops:
     ) -> None:
         """Warning emitted when second hop uses a different provider than requested."""
         expected_out = tmp_path / "out.surf.gii"
-        second = MagicMock(spec=models.SurfaceTransform, provider="CIVET")
+        second = MagicMock(
+            spec=models.SurfaceTransform,
+            provider="CIVET",
+            references=None,
+            notes=None,
+        )
         second.fetch.return_value = tmp_path / "sphere_unproject_from.surf.gii"
 
         ops.cache.get_surface_transform.return_value = second

--- a/tests/unit/graph/test_ops.py
+++ b/tests/unit/graph/test_ops.py
@@ -41,6 +41,8 @@ class TestTwoHops:
         first = MagicMock(
             spec=models.SurfaceTransform,
             fetch=MagicMock(return_value=sphere_project_to),
+            source_space="A",
+            target_space="B",
             provider="RheMap",
             references=None,
             notes=None,
@@ -52,6 +54,8 @@ class TestTwoHops:
         second = MagicMock(
             spec=models.SurfaceTransform,
             fetch=MagicMock(return_value=sphere_unproject_from),
+            source_space="B",
+            target_space="C",
             provider="RheMap",
             references=None,
             notes=None,
@@ -189,6 +193,8 @@ class TestTwoHops:
         expected_out = tmp_path / "out.surf.gii"
         first = MagicMock(
             spec=models.SurfaceTransform,
+            source_space="A",
+            target_space="B",
             provider="CIVET",
             references=None,
             notes=None,
@@ -238,6 +244,8 @@ class TestTwoHops:
         expected_out = tmp_path / "out.surf.gii"
         second = MagicMock(
             spec=models.SurfaceTransform,
+            source_space="B",
+            target_space="C",
             provider="CIVET",
             references=None,
             notes=None,

--- a/tests/unit/graph/test_ops.py
+++ b/tests/unit/graph/test_ops.py
@@ -14,6 +14,7 @@ from neuromaps_prime.graph.transforms.surface import SurfaceTransformOps
 from neuromaps_prime.graph.utils import GraphUtils
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 _LOGGER = "neuromaps_prime.graph.transforms.surface"
@@ -30,36 +31,17 @@ class TestTwoHops:
         return SurfaceTransformOps(cache=cache, utils=utils)
 
     @pytest.fixture
-    def mock_transforms(self, tmp_path: Path) -> dict[str, MagicMock]:
+    def mock_transforms(
+        self,
+        mock_surface_transform_factory: Callable[..., MagicMock],
+    ) -> dict[str, MagicMock]:
         """Create mock transforms with fetchable paths."""
-        sphere_in = tmp_path / "sphere_in.surf.gii"
-        sphere_project_to = tmp_path / "sphere_project_to.surf.gii"
-        sphere_unproject_from = tmp_path / "sphere_unproject_from.surf.gii"
-        for f in (sphere_in, sphere_project_to, sphere_unproject_from):
-            f.touch()
-
-        first = MagicMock(
-            spec=models.SurfaceTransform,
-            fetch=MagicMock(return_value=sphere_project_to),
-            source_space="A",
-            target_space="B",
-            provider="RheMap",
-            references=None,
-            notes=None,
-        )
+        first = mock_surface_transform_factory(source_space="A", target_space="B")
         mid_atlas = MagicMock(
             spec=models.SurfaceAtlas,
-            fetch=MagicMock(return_value=sphere_project_to),
+            fetch=MagicMock(return_value=first.fetch.return_value),
         )
-        second = MagicMock(
-            spec=models.SurfaceTransform,
-            fetch=MagicMock(return_value=sphere_unproject_from),
-            source_space="B",
-            target_space="C",
-            provider="RheMap",
-            references=None,
-            notes=None,
-        )
+        second = mock_surface_transform_factory(source_space="B", target_space="C")
         return {"first": first, "mid_atlas": mid_atlas, "second": second}
 
     def test_two_hops_success(
@@ -186,20 +168,15 @@ class TestTwoHops:
         self,
         ops: SurfaceTransformOps,
         mock_transforms: dict[str, MagicMock],
+        mock_surface_transform_factory: Callable[..., MagicMock],
         tmp_path: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warning emitted when first hop uses a different provider than requested."""
         expected_out = tmp_path / "out.surf.gii"
-        first = MagicMock(
-            spec=models.SurfaceTransform,
-            source_space="A",
-            target_space="B",
-            provider="CIVET",
-            references=None,
-            notes=None,
+        first = mock_surface_transform_factory(
+            source_space="A", target_space="B", provider="CIVET"
         )
-        first.fetch.return_value = tmp_path / "sphere_in.surf.gii"
 
         ops.cache.get_surface_transform.return_value = mock_transforms["second"]
         ops.cache.get_surface_atlas.return_value = mock_transforms["mid_atlas"]
@@ -237,20 +214,15 @@ class TestTwoHops:
         self,
         ops: SurfaceTransformOps,
         mock_transforms: dict[str, MagicMock],
+        mock_surface_transform_factory: Callable[..., MagicMock],
         tmp_path: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Warning emitted when second hop uses a different provider than requested."""
         expected_out = tmp_path / "out.surf.gii"
-        second = MagicMock(
-            spec=models.SurfaceTransform,
-            source_space="B",
-            target_space="C",
-            provider="CIVET",
-            references=None,
-            notes=None,
+        second = mock_surface_transform_factory(
+            source_space="B", target_space="C", provider="CIVET"
         )
-        second.fetch.return_value = tmp_path / "sphere_unproject_from.surf.gii"
 
         ops.cache.get_surface_transform.return_value = second
         ops.cache.get_surface_atlas.return_value = mock_transforms["mid_atlas"]

--- a/tests/unit/graph/test_utils.py
+++ b/tests/unit/graph/test_utils.py
@@ -1,0 +1,119 @@
+"""Unit tests for GraphUtils."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from neuromaps_prime.graph.utils import GraphUtils
+
+
+class TestCollectSpaceMetadata:
+    """Tests for GraphUtils.collect_space_metadata."""
+
+    @pytest.fixture
+    def utils(self) -> GraphUtils:
+        """Create GraphUtils with a mocked graph and cache."""
+        return MagicMock(spec=GraphUtils)  # type: ignore[return-value]
+
+    def _make_node(
+        self, references: list[str | dict[str, str]] | None = None
+    ) -> MagicMock:
+        """Create a mock Node with the given references."""
+        return MagicMock(references=references)
+
+    def test_returns_none_when_no_references(self, utils: MagicMock) -> None:
+        """Returns None when all spaces have no references."""
+        utils.get_node_data.return_value = self._make_node(references=None)
+
+        with patch(
+            "neuromaps_prime.graph.utils.GraphUtils.collect_space_metadata",
+            wraps=GraphUtils.collect_space_metadata,
+        ):
+            result = GraphUtils.collect_space_metadata(utils, ["A", "B"])
+
+        assert result is None
+        utils.get_node_data.assert_any_call("A")
+        utils.get_node_data.assert_any_call("B")
+
+    def test_returns_none_when_references_are_empty(self, utils: MagicMock) -> None:
+        """Returns None when all spaces have empty references."""
+        utils.get_node_data.return_value = self._make_node(references=[])
+
+        result = GraphUtils.collect_space_metadata(utils, ["A"])
+        assert result is None
+
+    def test_returns_formatted_metadata_when_references_exist(
+        self, utils: MagicMock
+    ) -> None:
+        """Returns space metadata dicts when references are present."""
+        utils.get_node_data.return_value = self._make_node(
+            references=["Smith et al. 2020"]
+        )
+
+        result = GraphUtils.collect_space_metadata(utils, ["A", "B"])  # type: ignore[arg-type]
+
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["space"] == "A"
+        assert result[0]["references"] == ["Smith et al. 2020"]
+        assert result[1]["space"] == "B"
+        assert result[1]["references"] == ["Smith et al. 2020"]
+
+    def test_deduplicates_spaces(self, utils: MagicMock) -> None:
+        """Skips spaces that appear multiple times in the path."""
+        utils.get_node_data.return_value = self._make_node(references=["Citation A"])
+
+        result = GraphUtils.collect_space_metadata(  # type: ignore[arg-type]
+            utils,
+            ["A", "B", "A", "C"],
+        )
+
+        assert result is not None
+        assert len(result) == 3
+        space_names = [entry["space"] for entry in result]
+        assert space_names == ["A", "B", "C"]
+        # A is only looked up once
+        utils.get_node_data.assert_called()
+        call_args = [c[0][0] for c in utils.get_node_data.call_args_list]
+        assert call_args == ["A", "B", "C"]
+
+    def test_format_reference_called_for_each_raw_ref(self, utils: MagicMock) -> None:
+        """format_reference is called for each raw reference."""
+        utils.get_node_data.return_value = self._make_node(
+            references=[
+                "Simple ref",
+                {"citation": "Author et al.", "doi": "10.1234/test"},
+            ]
+        )
+
+        result = GraphUtils.collect_space_metadata(utils, ["A"])  # type: ignore[arg-type]
+
+        assert result is not None
+        assert result[0]["space"] == "A"
+        assert len(result[0]["references"]) == 2
+        assert result[0]["references"][0] == "Simple ref"
+        assert "Author et al." in result[0]["references"][1]
+        assert "10.1234/test" in result[0]["references"][1]
+
+    def test_skips_spaces_with_no_references(self, utils: MagicMock) -> None:
+        """Only includes spaces that have formatted references."""
+        node_a = self._make_node(references=["A ref"])
+        node_b = self._make_node(references=None)
+        node_c = self._make_node(references=["C ref"])
+
+        utils.get_node_data.side_effect = [node_a, node_b, node_c]
+
+        result = GraphUtils.collect_space_metadata(utils, ["A", "B", "C"])  # type: ignore[arg-type]
+
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["space"] == "A"
+        assert result[1]["space"] == "C"
+
+    def test_empty_path_returns_none(self, utils: MagicMock) -> None:
+        """Returns None for an empty space path."""
+        result = GraphUtils.collect_space_metadata(utils, [])  # type: ignore[arg-type]
+        assert result is None
+        utils.get_node_data.assert_not_called()

--- a/tests/unit/graph/transformers/conftest.py
+++ b/tests/unit/graph/transformers/conftest.py
@@ -1,0 +1,93 @@
+"""Shared fixtures for transformer unit tests.
+
+Provides factory fixtures that construct MagicMock instances with the
+standard transform attributes (source_space, target_space, provider,
+references, notes) so individual test modules don't repeat the same
+boilerplate.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from neuromaps_prime.graph import models
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+@pytest.fixture
+def mock_surface_transform_factory(tmp_path: Path) -> Callable[..., MagicMock]:
+    """Factory fixture that returns a MagicMock with SurfaceTransform attributes.
+
+    All five attributes required for metadata collection are set to
+    sensible defaults.  Pass keyword arguments to override.
+
+    Examples::
+
+        xfm = mock_surface_transform_factory(
+            source_space="A", target_space="B"
+        )
+        xfm.fetch.return_value  -> tmp_path / "sphere.surf.gii"
+    """
+
+    def _make(
+        source_space: str = "X",
+        target_space: str = "Y",
+        provider: str = "RheMap",
+        references: list[str] | None = None,
+        notes: list[str] | None = None,
+    ) -> MagicMock:
+        sphere_file = tmp_path / "sphere.surf.gii"
+        sphere_file.touch()
+        mock = MagicMock(
+            spec=models.SurfaceTransform,
+            source_space=source_space,
+            target_space=target_space,
+            provider=provider,
+            references=references,
+            notes=notes,
+        )
+        mock.fetch.return_value = sphere_file
+        return mock
+
+    return _make
+
+
+@pytest.fixture
+def mock_volume_transform_factory(tmp_path: Path) -> Callable[..., MagicMock]:
+    """Factory fixture that returns a MagicMock with VolumeTransform attributes.
+
+    Examples::
+
+        xfm = mock_volume_transform_factory(
+            source_space="Yerkes19", target_space="NMT2"
+        )
+        xfm.fetch.return_value  -> tmp_path / "transform.nii.gz"
+    """
+
+    def _make(
+        source_space: str = "X",
+        target_space: str = "Y",
+        provider: str = "Test",
+        references: list[str] | None = None,
+        notes: list[str] | None = None,
+    ) -> MagicMock:
+        warp_file = tmp_path / "transform.nii.gz"
+        warp_file.touch()
+        mock = MagicMock(
+            spec=models.VolumeTransform,
+            source_space=source_space,
+            target_space=target_space,
+            provider=provider,
+            references=references,
+            notes=notes,
+        )
+        mock.fetch.return_value = warp_file
+        return mock
+
+    return _make

--- a/tests/unit/graph/transformers/test_surf_to_surf.py
+++ b/tests/unit/graph/transformers/test_surf_to_surf.py
@@ -105,7 +105,7 @@ class TestSurfaceToSurfaceTransformer:
     def test_no_transform(
         self, mock_transformer: NeuromapsGraph, basic_params: BasicParams
     ) -> None:
-        """Test None returned if transform not found."""
+        """Test falsy result if transform not found."""
         mock_transformer.surface_ops.transform_surface.return_value = None
 
         with patch(
@@ -115,7 +115,8 @@ class TestSurfaceToSurfaceTransformer:
             out = mock_transformer.surface_to_surface_transformer(
                 transformer_type="metric", **basic_params._asdict()
             )
-            assert out is None
+            assert not out
+            assert out.path is None
 
     def test_fetch_surface_atlas_errors(
         self, mock_transformer: NeuromapsGraph, basic_params: BasicParams

--- a/tests/unit/graph/transformers/test_surf_to_surf.py
+++ b/tests/unit/graph/transformers/test_surf_to_surf.py
@@ -288,33 +288,20 @@ class TestSurfaceToSurfaceTransformPrivate:
         assert result.file_path == composed_path
         assert result.weight == 2.0
 
-    def test_two_hops(self, mock_graph: NeuromapsGraph, tmp_path: Path) -> None:
+    def test_two_hops(
+        self,
+        mock_graph: NeuromapsGraph,
+        mock_surface_transform_factory: MagicMock,
+        tmp_path: Path,
+    ) -> None:
         """Test two hop functionality."""
-        first_xfm = MagicMock(
-            spec=models.SurfaceTransform,
-            source_space="A",
-            target_space="B",
-            provider="RheMap",
-            references=None,
-            notes=None,
-        )
-        first_xfm.fetch.return_value = tmp_path / "sphere_in.surf.gii"
-        first_xfm.fetch.return_value.touch()
+        first_xfm = mock_surface_transform_factory(source_space="A", target_space="B")
 
         mid_atlas = MagicMock(spec=models.SurfaceAtlas)
         mid_atlas.fetch.return_value = tmp_path / "sphere_project.surf.gii"
         mid_atlas.fetch.return_value.touch()
 
-        target_xfm = MagicMock(
-            spec=models.SurfaceTransform,
-            source_space="B",
-            target_space="C",
-            provider="RheMap",
-            references=None,
-            notes=None,
-        )
-        target_xfm.fetch.return_value = tmp_path / "sphere_unproject.surf.gii"
-        target_xfm.fetch.return_value.touch()
+        target_xfm = mock_surface_transform_factory(source_space="B", target_space="C")
 
         output_path = tmp_path / "output_surf.gii"
         output_path.touch()
@@ -364,18 +351,12 @@ class TestSurfaceToSurfaceTransformPrivate:
             )
 
     def test_two_hops_no_mid_atlas(
-        self, mock_graph: NeuromapsGraph, tmp_path: Path
+        self, mock_graph: NeuromapsGraph, mock_surface_transform_factory: MagicMock
     ) -> None:
         """Test error raised when no mid atlas."""
-        first_transform = MagicMock(
-            spec=models.SurfaceTransform,
-            source_space="A",
-            target_space="B",
-            provider="RheMap",
-            references=None,
-            notes=None,
+        first_transform = mock_surface_transform_factory(
+            source_space="A", target_space="B"
         )
-        first_transform.fetch.return_value = tmp_path / "sphere_in.surf.gii"
         mock_graph.surface_ops.utils.find_common_density = MagicMock(return_value="41k")
         mock_graph.surface_ops.cache.get_surface_atlas = MagicMock(return_value=None)
         with pytest.raises(ValueError, match="No sphere atlas found for"):
@@ -390,18 +371,15 @@ class TestSurfaceToSurfaceTransformPrivate:
             )
 
     def test_two_hops_no_target_xfm(
-        self, mock_graph: NeuromapsGraph, tmp_path: Path
+        self,
+        mock_graph: NeuromapsGraph,
+        mock_surface_transform_factory: MagicMock,
+        tmp_path: Path,
     ) -> None:
         """Test error raised when no target transformation."""
-        first_transform = MagicMock(
-            spec=models.SurfaceTransform,
-            source_space="A",
-            target_space="B",
-            provider="RheMap",
-            references=None,
-            notes=None,
+        first_transform = mock_surface_transform_factory(
+            source_space="A", target_space="B"
         )
-        first_transform.fetch.return_value = tmp_path / "sphere_in.surf.gii"
         mid_atlas = MagicMock(spec=models.SurfaceAtlas)
         mid_atlas.fetch.return_value = tmp_path / "sphere_project.surf.gii"
 

--- a/tests/unit/graph/transformers/test_surf_to_surf.py
+++ b/tests/unit/graph/transformers/test_surf_to_surf.py
@@ -167,28 +167,13 @@ class TestSurfaceToSurfaceTransformPrivate:
                 density="1k",
                 hemisphere="left",
                 output_file_path="same_target",
-                add_edge=False,
-            )
-
-    def test_no_valid_path(self, mock_graph: NeuromapsGraph) -> None:
-        """Test error raised if no valid path found."""
-        mock_graph.surface_ops.utils.find_path = MagicMock(return_value=["only_source"])
-        with pytest.raises(ValueError, match="No valid surface path from"):
-            mock_graph.surface_ops._resolve_sphere_transform(
-                source="NMT2Sym",
-                target="fsLR",
-                density="32k",
-                hemisphere="left",
-                output_file_path="no_path",
+                space_path=["A"],
                 add_edge=False,
             )
 
     def test_single_hop(self, mock_graph: NeuromapsGraph) -> None:
         """Test single-hop surface transformation."""
         mock_result = MagicMock(spec=models.SurfaceTransform)
-        mock_graph.surface_ops.utils.find_path = MagicMock(
-            return_value=["Yerkes19", "fsLR"]
-        )
         mock_graph.surface_ops.cache.get_surface_transform = MagicMock(
             return_value=mock_result
         )
@@ -198,6 +183,7 @@ class TestSurfaceToSurfaceTransformPrivate:
             density="32k",
             hemisphere="right",
             output_file_path="single_hop",
+            space_path=["Yerkes19", "fsLR"],
             add_edge=False,
         )
         mock_graph.surface_ops.cache.get_surface_transform.assert_called_once()
@@ -206,9 +192,6 @@ class TestSurfaceToSurfaceTransformPrivate:
     def test_multi_hop(self, mock_graph: NeuromapsGraph) -> None:
         """Test multi-hop path surface transformation."""
         mock_result = MagicMock(spec=models.SurfaceTransform)
-        mock_graph.surface_ops.utils.find_path = MagicMock(
-            return_value=["CIVETNMT", "Yerkes19", "fsLR"]
-        )
         mock_graph.surface_ops._compose_multihop = MagicMock(return_value=mock_result)
         out = mock_graph.surface_ops._resolve_sphere_transform(
             source="CIVETNMT",
@@ -216,6 +199,7 @@ class TestSurfaceToSurfaceTransformPrivate:
             density="32k",
             hemisphere="right",
             output_file_path="multi_hop",
+            space_path=["CIVETNMT", "Yerkes19", "fsLR"],
             add_edge=False,
         )
         mock_graph.surface_ops._compose_multihop.assert_called_once()
@@ -308,6 +292,9 @@ class TestSurfaceToSurfaceTransformPrivate:
         """Test two hop functionality."""
         first_xfm = MagicMock(
             spec=models.SurfaceTransform,
+            source_space="A",
+            target_space="B",
+            provider="RheMap",
             references=None,
             notes=None,
         )
@@ -320,6 +307,9 @@ class TestSurfaceToSurfaceTransformPrivate:
 
         target_xfm = MagicMock(
             spec=models.SurfaceTransform,
+            source_space="B",
+            target_space="C",
+            provider="RheMap",
             references=None,
             notes=None,
         )
@@ -379,6 +369,9 @@ class TestSurfaceToSurfaceTransformPrivate:
         """Test error raised when no mid atlas."""
         first_transform = MagicMock(
             spec=models.SurfaceTransform,
+            source_space="A",
+            target_space="B",
+            provider="RheMap",
             references=None,
             notes=None,
         )
@@ -402,6 +395,9 @@ class TestSurfaceToSurfaceTransformPrivate:
         """Test error raised when no target transformation."""
         first_transform = MagicMock(
             spec=models.SurfaceTransform,
+            source_space="A",
+            target_space="B",
+            provider="RheMap",
             references=None,
             notes=None,
         )
@@ -447,6 +443,7 @@ class TestTransformSurface:
         """Mock surface operations."""
         graph.surface_ops.cache = MagicMock()
         graph.surface_ops.utils = MagicMock()
+        graph.surface_ops.utils.find_path.return_value = ["fsLR", "MNI152"]
         graph.surface_ops._resolve_sphere_transform = MagicMock()
         return graph
 
@@ -475,7 +472,12 @@ class TestTransformSurface:
     ) -> None:
         """Metric and label paths call correct resample fn and return output path."""
         mock_ops.surface_ops._resolve_sphere_transform.return_value = MagicMock(
-            fetch=MagicMock(return_value=tmp_path / "sphere.surf.gii")
+            fetch=MagicMock(return_value=tmp_path / "sphere.surf.gii"),
+            source_space="fsLR",
+            target_space="MNI152",
+            provider="Test",
+            references=None,
+            notes=None,
         )
         mock_ops.surface_ops.cache.require_surface_atlas.return_value = MagicMock(
             fetch=MagicMock(return_value=tmp_path / "area.surf.gii")
@@ -499,7 +501,14 @@ class TestTransformSurface:
     ) -> None:
         """source_density=None triggers estimate_surface_density."""
         basic_params["source_density"] = None
-        mock_ops.surface_ops._resolve_sphere_transform.return_value = MagicMock()
+        mock_ops.surface_ops._resolve_sphere_transform.return_value = MagicMock(
+            fetch=MagicMock(return_value=tmp_path / "sphere.surf.gii"),
+            source_space="fsLR",
+            target_space="MNI152",
+            provider="Test",
+            references=None,
+            notes=None,
+        )
         mock_ops.surface_ops.cache.require_surface_atlas.return_value = MagicMock(
             fetch=MagicMock(return_value=tmp_path / "area.surf.gii")
         )
@@ -520,7 +529,14 @@ class TestTransformSurface:
     ) -> None:
         """target_density=None calls find_highest_density."""
         basic_params["target_density"] = None
-        mock_ops.surface_ops._resolve_sphere_transform.return_value = MagicMock()
+        mock_ops.surface_ops._resolve_sphere_transform.return_value = MagicMock(
+            fetch=MagicMock(return_value=tmp_path / "sphere.surf.gii"),
+            source_space="fsLR",
+            target_space="MNI152",
+            provider="Test",
+            references=None,
+            notes=None,
+        )
         mock_ops.surface_ops.utils.find_highest_density.return_value = "164k"
         mock_ops.surface_ops.cache.require_surface_atlas.return_value = MagicMock(
             fetch=MagicMock(return_value=tmp_path / "area.surf.gii")

--- a/tests/unit/graph/transformers/test_surf_to_surf.py
+++ b/tests/unit/graph/transformers/test_surf_to_surf.py
@@ -538,3 +538,12 @@ class TestTransformSurface:
         assert not result
         assert result.path is None
         mock_ops.surface_ops.cache.require_surface_atlas.assert_not_called()
+
+    def test_no_valid_path(self, mock_ops: NeuromapsGraph, basic_params: dict) -> None:
+        """Raises ValueError when find_path returns fewer than two spaces."""
+        mock_ops.surface_ops.utils.find_path.return_value = ["fsLR"]
+        with pytest.raises(ValueError, match="No valid surface path"):
+            mock_ops.surface_ops.transform_surface(
+                transformer_type="metric", **basic_params
+            )
+        mock_ops.surface_ops._resolve_sphere_transform.assert_not_called()

--- a/tests/unit/graph/transformers/test_surf_to_surf.py
+++ b/tests/unit/graph/transformers/test_surf_to_surf.py
@@ -74,7 +74,8 @@ class TestSurfaceToSurfaceTransformer:
     ) -> None:
         """Test successful metric/label transformation delegates to surface ops."""
         mock_output = Path(basic_params.output_file_path)
-        mock_transformer.surface_ops.transform_surface.return_value = mock_output
+        mock_result = models.TransformResult(output_path=mock_output)
+        mock_transformer.surface_ops.transform_surface.return_value = mock_result
 
         with patch(
             "neuromaps_prime.transforms.utils.estimate_surface_density",
@@ -106,7 +107,9 @@ class TestSurfaceToSurfaceTransformer:
         self, mock_transformer: NeuromapsGraph, basic_params: BasicParams
     ) -> None:
         """Test falsy result if transform not found."""
-        mock_transformer.surface_ops.transform_surface.return_value = None
+        mock_transformer.surface_ops.transform_surface.return_value = (
+            models.TransformResult()
+        )
 
         with patch(
             "neuromaps_prime.transforms.utils.estimate_surface_density",
@@ -277,7 +280,9 @@ class TestSurfaceToSurfaceTransformPrivate:
         composed_path = tmp_path / "composed_surf.gii"
         composed_path.touch()
         mock_graph.surface_ops._hop_output_path = MagicMock(return_value=hop_output)
-        mock_graph.surface_ops._two_hops = MagicMock(return_value=composed_path)
+        mock_graph.surface_ops._two_hops = MagicMock(
+            return_value=models.TransformResult(output_path=composed_path)
+        )
 
         result = mock_graph.surface_ops._compose_next_hop(
             path=["A", "B", "C"],
@@ -301,7 +306,11 @@ class TestSurfaceToSurfaceTransformPrivate:
 
     def test_two_hops(self, mock_graph: NeuromapsGraph, tmp_path: Path) -> None:
         """Test two hop functionality."""
-        first_xfm = MagicMock(spec=models.SurfaceTransform)
+        first_xfm = MagicMock(
+            spec=models.SurfaceTransform,
+            references=None,
+            notes=None,
+        )
         first_xfm.fetch.return_value = tmp_path / "sphere_in.surf.gii"
         first_xfm.fetch.return_value.touch()
 
@@ -309,7 +318,11 @@ class TestSurfaceToSurfaceTransformPrivate:
         mid_atlas.fetch.return_value = tmp_path / "sphere_project.surf.gii"
         mid_atlas.fetch.return_value.touch()
 
-        target_xfm = MagicMock(spec=models.SurfaceTransform)
+        target_xfm = MagicMock(
+            spec=models.SurfaceTransform,
+            references=None,
+            notes=None,
+        )
         target_xfm.fetch.return_value = tmp_path / "sphere_unproject.surf.gii"
         target_xfm.fetch.return_value.touch()
 
@@ -338,7 +351,8 @@ class TestSurfaceToSurfaceTransformPrivate:
                 first_transform=first_xfm,
             )
 
-        assert result == output_path
+        assert result.path == output_path
+        assert isinstance(result, models.TransformResult)
         mock_graph.surface_ops.utils.find_common_density.assert_called_once()
         mock_graph.surface_ops.cache.get_surface_atlas.assert_called_once()
         mock_project.assert_called_once()
@@ -363,7 +377,11 @@ class TestSurfaceToSurfaceTransformPrivate:
         self, mock_graph: NeuromapsGraph, tmp_path: Path
     ) -> None:
         """Test error raised when no mid atlas."""
-        first_transform = MagicMock(spec=models.SurfaceTransform)
+        first_transform = MagicMock(
+            spec=models.SurfaceTransform,
+            references=None,
+            notes=None,
+        )
         first_transform.fetch.return_value = tmp_path / "sphere_in.surf.gii"
         mock_graph.surface_ops.utils.find_common_density = MagicMock(return_value="41k")
         mock_graph.surface_ops.cache.get_surface_atlas = MagicMock(return_value=None)
@@ -382,7 +400,11 @@ class TestSurfaceToSurfaceTransformPrivate:
         self, mock_graph: NeuromapsGraph, tmp_path: Path
     ) -> None:
         """Test error raised when no target transformation."""
-        first_transform = MagicMock(spec=models.SurfaceTransform)
+        first_transform = MagicMock(
+            spec=models.SurfaceTransform,
+            references=None,
+            notes=None,
+        )
         first_transform.fetch.return_value = tmp_path / "sphere_in.surf.gii"
         mid_atlas = MagicMock(spec=models.SurfaceAtlas)
         mid_atlas.fetch.return_value = tmp_path / "sphere_project.surf.gii"
@@ -470,6 +492,7 @@ class TestTransformSurface:
                 transformer_type=transformer_type, **basic_params
             )
         assert result == expected_out
+        assert isinstance(result, models.TransformResult)
 
     def test_source_density_estimated_when_none(
         self, mock_ops: NeuromapsGraph, basic_params: dict, tmp_path: Path
@@ -513,10 +536,11 @@ class TestTransformSurface:
     def test_returns_none_when_no_sphere_transform(
         self, mock_ops: NeuromapsGraph, basic_params: dict
     ) -> None:
-        """Returns None when _resolve_sphere_transform returns None."""
+        """Returns falsy TransformResult when _resolve_sphere_transform returns None."""
         mock_ops.surface_ops._resolve_sphere_transform.return_value = None
         result = mock_ops.surface_ops.transform_surface(
             transformer_type="metric", **basic_params
         )
-        assert result is None
+        assert not result
+        assert result.path is None
         mock_ops.surface_ops.cache.require_surface_atlas.assert_not_called()

--- a/tests/unit/graph/transformers/test_surf_to_vol.py
+++ b/tests/unit/graph/transformers/test_surf_to_vol.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from neuromaps_prime.graph.models import TransformResult
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Literal
@@ -84,7 +86,9 @@ class TestTransformSurfaceToVolume:
         expected_ext = "label.gii" if transformer_type == "label" else "shape.gii"
         out_surface = tmp_path / f"out.{expected_ext}"
 
-        mock_ops.surface_ops.transform_surface.return_value = out_surface
+        mock_ops.surface_ops.transform_surface.return_value = TransformResult(
+            output_path=out_surface
+        )
         mock_ops.surface_ops.cache.get_surface_atlas.side_effect = (
             self.make_atlas_side_effect(tmp_path)
         )
@@ -112,7 +116,9 @@ class TestTransformSurfaceToVolume:
     ) -> None:
         """Test target_density fallback to highest available when None."""
         params = basic_params._replace(target_density=None)
-        mock_ops.surface_ops.transform_surface.return_value = tmp_path / "out.shape.gii"
+        mock_ops.surface_ops.transform_surface.return_value = TransformResult(
+            output_path=tmp_path / "out.shape.gii"
+        )
         mock_ops.surface_ops.utils.find_highest_density.return_value = "164k"
         mock_ops.surface_ops.cache.get_surface_atlas.side_effect = (
             self.make_atlas_side_effect(tmp_path)
@@ -140,7 +146,7 @@ class TestTransformSurfaceToVolume:
         self, mock_ops: NeuromapsGraph, basic_params: BasicParams
     ) -> None:
         """FileNotFoundError raised when the intermediate surface transform fails."""
-        mock_ops.surface_ops.transform_surface.return_value = None
+        mock_ops.surface_ops.transform_surface.return_value = TransformResult()
 
         with pytest.raises(FileNotFoundError, match="Unable to perform transformation"):
             mock_ops.surface_ops.transform_surface_to_volume(
@@ -151,7 +157,9 @@ class TestTransformSurfaceToVolume:
         self, mock_ops: NeuromapsGraph, basic_params: BasicParams, tmp_path: Path
     ) -> None:
         """FileNotFoundError raised when target surface atlas cannot be found."""
-        mock_ops.surface_ops.transform_surface.return_value = tmp_path / "out.shape.gii"
+        mock_ops.surface_ops.transform_surface.return_value = TransformResult(
+            output_path=tmp_path / "out.shape.gii"
+        )
         mock_ops.surface_ops.cache.get_surface_atlas.return_value = None
 
         with pytest.raises(FileNotFoundError, match="Unable to find target surface"):

--- a/tests/unit/graph/transformers/test_vol_to_surf.py
+++ b/tests/unit/graph/transformers/test_vol_to_surf.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from neuromaps_prime.graph.models import TransformResult
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Literal
@@ -110,7 +112,7 @@ class TestVolumeToSurfaceTransformer:
             ) as mock_surface_project,
         ):
             mock_transformer.volume_ops.surface_ops.transform_surface.return_value = (
-                expected_output
+                TransformResult(output_path=expected_output)
             )
             result = mock_transformer.volume_to_surface_transformer(
                 **basic_params._asdict()
@@ -145,7 +147,7 @@ class TestVolumeToSurfaceTransformer:
             self.make_atlas_side_effect(tmp_path)
         )
         mock_transformer.volume_ops.surface_ops.transform_surface.return_value = (
-            projected_file
+            TransformResult(output_path=projected_file)
         )
         with (
             patch(

--- a/tests/unit/graph/transformers/test_vol_to_vol.py
+++ b/tests/unit/graph/transformers/test_vol_to_vol.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from neuromaps_prime.graph import NeuromapsGraph, models
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class BasicParams(NamedTuple):
@@ -47,18 +50,12 @@ class TestVolumeToVolumeTransformer:
         )
 
     @pytest.fixture
-    def mock_volume_transform(self, tmp_path: Path) -> MagicMock:
+    def mock_volume_transform(
+        self, mock_volume_transform_factory: Callable[..., MagicMock]
+    ) -> MagicMock:
         """Create mock volume transform object."""
-        transform_file = tmp_path / "transform.nii.gz"
-        transform_file.touch()
-        return MagicMock(
-            spec=models.VolumeTransform,
-            fetch=MagicMock(return_value=transform_file),
-            source_space="Yerkes19",
-            target_space="NMT2Sym",
-            provider="Test",
-            references=None,
-            notes=None,
+        return mock_volume_transform_factory(
+            source_space="Yerkes19", target_space="NMT2Sym"
         )
 
     @pytest.fixture

--- a/tests/unit/graph/transformers/test_vol_to_vol.py
+++ b/tests/unit/graph/transformers/test_vol_to_vol.py
@@ -54,6 +54,9 @@ class TestVolumeToVolumeTransformer:
         return MagicMock(
             spec=models.VolumeTransform,
             fetch=MagicMock(return_value=transform_file),
+            source_space="Yerkes19",
+            target_space="NMT2Sym",
+            provider="Test",
             references=None,
             notes=None,
         )

--- a/tests/unit/graph/transformers/test_vol_to_vol.py
+++ b/tests/unit/graph/transformers/test_vol_to_vol.py
@@ -52,7 +52,10 @@ class TestVolumeToVolumeTransformer:
         transform_file = tmp_path / "transform.nii.gz"
         transform_file.touch()
         return MagicMock(
-            spec=models.VolumeTransform, fetch=MagicMock(return_value=transform_file)
+            spec=models.VolumeTransform,
+            fetch=MagicMock(return_value=transform_file),
+            references=None,
+            notes=None,
         )
 
     @pytest.fixture


### PR DESCRIPTION
## This PR:
Adds structured metadata (references and caveats) to all transform pipeline return values. Every transform method now returns a `TransformResult` object (instead of just a `Path`) that carries per-hop transform metadata, per-space node-level references, and supports writing to disk as a Markdown or JSON file. If transformation is verbose, a grouped summary is printed.

The return type change is backward compatible: `TransformResult` implements `__fspath__`, `__bool__`, `__eq__` (against `Path`), and delegates `exists()`, `parent`, `name`, and `is_file()` so existing code that treats the return value as a `Path` continues to work. 

<details>
<summary><h3>Detailed Changes</h3></summary>

**New types and module**
- **`TransformResult`** (`models.py`) — wraps the output `Path` and a `TransformMetadata` object. Implements path-like protocol (`__fspath__`, `__bool__`, `__eq__`, `exists`, `parent`, `name`, `is_file`) for drop-in compatibility with existing code expecting `Path`. Provides `save_metadata()` for disk serialization (`.md` Markdown or `.json`).
- **`TransformMetadata`** (`models.py`) — holds `transforms` (per-hop dicts) and `spaces` (per-space reference dicts), separating transform-level and node-level provenance.
- **`HopMetadataDict` / `SpaceMetadataDict`** (`models.py`) — TypedDicts defining the shape of hop and space metadata entries.
- **`metadata.py`** — new module with `format_reference()` (formats structured `{citation, doi, url}` dicts into pipe-separated strings) and `print_metadata_summary()` (grouped terminal output of spaces, hops, references, and caveats).
- New public exports in `__init__.py`: `TransformResult`, `TransformMetadata`, `HopMetadataDict`, `SpaceMetadataDict`.

**Core API — `NeuromapsGraph`**
- All four transformer methods (`surface_to_surface`, `surface_to_volume`, `volume_to_volume`, `volume_to_surface`) now accept `metadata_path: Path | None` and return `TransformResult` instead of `Path | None`.
- Metadata summary is printed automatically when `verbose >= 1`.
- When `metadata_path` is provided, metadata is written to disk on completion.

**Transform operations**
- **`SurfaceTransformOps`** — `transform_surface()` now collects per-hop metadata from the resolved sphere transform and node-level metadata from `GraphUtils.collect_space_metadata()`. Multi-hop composition (`_compose_multihop`, `_two_hops`) accumulates references and notes from each hop. Returns `TransformResult` in all cases (including failure, where `path` is `None`).
- **`VolumeTransformOps`** — `transform_volume()` collects hop and space metadata. `transform_volume_to_surface()` delegates to surface ops and propagates metadata.
- **`GraphUtils`** — new `collect_space_metadata()` method walks a space path, extracts node-level references, and deduplicates shared intermediate spaces.

**Tests**
- **`tests/unit/graph/test_metadata.py`** — covering `format_reference` and `print_metadata_summary`
- **`tests/unit/graph/test_model.py`** — extended with `TransformMetadata`, `TransformResult`, `save_metadata`, `__fspath__`, `__eq__` tests
- **`tests/unit/graph/test_utils.py`** — new tests for `collect_space_metadata`
- **`tests/unit/graph/conftest.py`** — shared factory fixtures to eliminate boilerplate
- All existing transformer tests updated for the new return type

### Backward Compatibility
- `TransformResult` behaves as a `Path` for comparison, boolean evaluation, filesystem path protocol, and common Path methods
- The `references` and `notes` properties provide flat lists
- The `metadata_path` parameter is optional and `None` by default
</details>

## Type of Change
- [ ] Bug fix
- [x] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)
- Closes #109 by @kaitj