### PR TITLE
Tf cycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,10 @@ dev = [
   "types-requests>=2.33.0.20260518"
 ]
 docs = ["pdoc>=15.0.4"]
-tests = ["pandas>=3.0.3"]
+tests = [
+  "pandas>=3.0.3",
+  "matplotlib-surface-plotting>=0.1.0"
+]
 validate = ["check-jsonschema>=0.37.1"]
 
 [build-system]

--- a/tests/regression/cycle.py
+++ b/tests/regression/cycle.py
@@ -1,0 +1,463 @@
+"""Cycle test: round-trip a surface metric through every return path.
+
+A *return path* (or *cycle*) is a simple path that starts and ends at the same
+space, e.g. ``A -> B -> A`` or ``A -> B -> C -> A``. If every surface transform
+along the path were perfect, a metric carried around the path would map back
+onto itself exactly. In practice each resampling step introduces error, so the
+Pearson correlation between the original metric and its round-trip is a proxy
+for the *combined* quality of the transforms traversed on that path.
+
+The cycle test therefore:
+
+1. enumerates every simple return path from an origin space over the
+   surface-to-surface layer of the graph;
+2. carries a seed metric hop-by-hop around each path back to the origin;
+3. correlates the round-tripped metric against the original.
+
+This module holds the reusable machinery (enumeration, round-trip, scoring) so
+that the deployed regression test and its unit test exercise *the same code*.
+The unit test (``tests/unit/test_cycle.py``) validates this machinery on a
+synthetic three-node network whose transforms are pure ``+/-120`` degree
+rotations, for which the ground-truth answer is known: every return path is the
+identity, so every correlation must be ~1.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from itertools import pairwise
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import networkx as nx
+import nibabel as nib
+import numpy as np
+
+if TYPE_CHECKING:
+    from neuromaps_prime.graph import NeuromapsGraph
+
+logger = logging.getLogger(__name__)
+
+SURFACE_EDGE = "surface_to_surface"
+
+
+def resolve_hop_transforms(
+    graph: "NeuromapsGraph",
+    path: tuple[str, ...],
+    hemisphere: Literal["left", "right"],
+    density: str,
+    edge_type: str = SURFACE_EDGE,
+) -> list[tuple[str, str, str, Path]]:
+    """Return the actual sphere transform file for every direct graph edge used.
+
+    Each *logical* hop ``(src, dst)`` in *path* may itself span multiple edges
+    inside the graph (if there is no direct registration).  This function
+    expands every logical hop into its shortest internal edge sequence and
+    looks up the on-disk transform file for each direct edge, giving a
+    complete audit trail of which files were used.
+
+    For each direct edge the cache is first queried at *density*; if no match
+    is found at that exact density (e.g. the reverse-direction transform is
+    registered at a different density), the first available density is used as
+    a fallback so the entry is never silently dropped.
+
+    Args:
+        graph: Populated :class:`~neuromaps_prime.graph.NeuromapsGraph`.
+        path: Cycle path, e.g. ``('A', 'B', 'C', 'A')``.
+        hemisphere: ``'left'`` or ``'right'``.
+        density: Preferred surface mesh density for the lookup.
+        edge_type: Graph edge layer to traverse (default ``'surface_to_surface'``).
+
+    Returns:
+        List of ``(source_space, target_space, density_used, file_path)``
+        tuples, one per direct graph edge, in traversal order.
+    """
+    rows: list[tuple[str, str, str, Path]] = []
+    for src, dst in pairwise(path):
+        internal_path = graph.surface_ops.utils.find_path(src, dst, edge_type)
+        for hop_src, hop_dst in pairwise(internal_path):
+            # Try exact density first.
+            transform = graph.surface_ops.cache.get_surface_transform(
+                source=hop_src,
+                target=hop_dst,
+                density=density,
+                hemisphere=hemisphere,
+                resource_type="sphere",
+            )
+            density_used = density
+            if transform is None:
+                # Fall back to any registered density for this edge.
+                candidates = graph.surface_ops.cache.get_surface_transforms(
+                    source=hop_src,
+                    target=hop_dst,
+                    hemisphere=hemisphere,
+                    resource_type="sphere",
+                )
+                if candidates:
+                    transform = candidates[0]
+                    density_used = transform.density
+                    logger.warning(
+                        "No sphere transform for %s -> %s at density %s (%s); "
+                        "using density %s instead.",
+                        hop_src,
+                        hop_dst,
+                        density,
+                        hemisphere,
+                        density_used,
+                    )
+                else:
+                    logger.warning(
+                        "No sphere transform found for %s -> %s (%s) at any density.",
+                        hop_src,
+                        hop_dst,
+                        hemisphere,
+                    )
+            if transform is not None:
+                rows.append((hop_src, hop_dst, density_used, transform.file_path))
+    return rows
+
+
+def _path_token(path: tuple[str, ...]) -> str:
+    """Return a short deterministic token for a traversal path."""
+    digest = hashlib.sha1("->".join(path).encode("utf-8")).hexdigest()[:12]
+    return f"{path[0]}_{path[-1]}_{len(path) - 1}h_{digest}"
+
+
+@dataclass(frozen=True)
+class CycleResult:
+    """Outcome of round-tripping a metric around one return path.
+
+    Attributes:
+        path: Ordered space names, starting and ending at the origin space.
+        pearson_r: Pearson correlation between the original metric and its
+            round-trip. Approaches ``1.0`` as the traversed transforms approach
+            a perfect identity.
+        max_abs_diff: Largest absolute vertex-wise difference between the
+            original and round-tripped metric.
+    """
+
+    path: tuple[str, ...]
+    pearson_r: float
+    max_abs_diff: float
+
+    @property
+    def label(self) -> str:
+        """Return a human-readable ``A -> B -> A`` label for the path."""
+        return " -> ".join(self.path)
+
+
+def find_return_paths(
+    graph: NeuromapsGraph,
+    origin: str,
+    edge_type: str = SURFACE_EDGE,
+    *,
+    max_length: int | None = None,
+    allow_revisits: bool = False,
+    max_paths: int | None = None,
+) -> list[tuple[str, ...]]:
+    """Enumerate every simple return path ``origin -> ... -> origin``.
+
+    Traversal is restricted to a single edge layer (surface-to-surface by
+    default) so that the cycle test scores one transform modality at a time.
+    By default this enumerates directed simple cycles (no repeated interior
+    nodes), rotated so that they start and end at ``origin``.
+
+    When ``allow_revisits=True``, this instead enumerates round-trips composed
+    of two directed simple legs: an outbound simple path from ``origin`` to a
+    turning node, plus a return simple path from that node back to ``origin``.
+    A node can therefore appear at most once per leg (at most twice overall),
+    which avoids degenerate ping-pong walks while still permitting bridge nodes
+    to be crossed once out and once back.
+
+    Args:
+        graph: Populated :class:`~neuromaps_prime.graph.NeuromapsGraph`.
+        origin: Space the metric starts from and must return to.
+        edge_type: Edge key to traverse (``'surface_to_surface'`` or
+            ``'volume_to_volume'``).
+        max_length: Optional cap on the number of edges in a path. ``None``
+            enumerates all simple cycles, which grows combinatorially on dense
+            graphs; bound it on the real graph. Required when
+            ``allow_revisits=True``.
+        allow_revisits: If ``True``, enumerate two-leg round-trips (outbound +
+            return simple paths) up to ``max_length``.
+        max_paths: Optional cap on number of returned paths. Useful with
+            ``allow_revisits=True`` to avoid combinatorial blow-up.
+
+    Returns:
+        Return paths sorted by length then lexicographically, e.g.
+        ``[('A', 'B', 'A'), ('A', 'C', 'A'), ('A', 'B', 'C', 'A'), ...]``.
+
+    Raises:
+        ValueError: If ``origin`` is not a node in the graph.
+    """
+    subgraph = graph.utils.get_subgraph(edge_type)
+    if origin not in subgraph:
+        raise ValueError(
+            f"Origin space '{origin}' is not in the '{edge_type}' layer. "
+            f"Available: {sorted(subgraph.nodes)}"
+        )
+
+    if not allow_revisits:
+        paths: list[tuple[str, ...]] = []
+        for cycle in nx.simple_cycles(subgraph, length_bound=max_length):
+            if origin not in cycle:
+                continue
+            # Rotate the directed cycle so it starts at origin, then close it.
+            start = cycle.index(origin)
+            rotated = cycle[start:] + cycle[:start] + [origin]
+            paths.append(tuple(rotated))
+        return sorted(paths, key=lambda p: (len(p), p))
+
+    if max_length is None:
+        raise ValueError("max_length is required when allow_revisits=True")
+
+    # Enumerate bounded round-trips built from two simple directed legs.
+    found: set[tuple[str, ...]] = set()
+    # Turning node cannot be origin, otherwise round-trip is length 0.
+    turn_nodes = [n for n in subgraph.nodes if n != origin]
+    for turn in turn_nodes:
+        # Outbound path: origin -> ... -> turn
+        for outbound in nx.all_simple_paths(
+            subgraph,
+            source=origin,
+            target=turn,
+            cutoff=max_length - 1,
+        ):
+            out_hops = len(outbound) - 1
+            if out_hops < 1:
+                continue
+
+            remaining = max_length - out_hops
+            if remaining < 1:
+                continue
+
+            # Return path: turn -> ... -> origin
+            for inbound in nx.all_simple_paths(
+                subgraph,
+                source=turn,
+                target=origin,
+                cutoff=remaining,
+            ):
+                in_hops = len(inbound) - 1
+                total_hops = out_hops + in_hops
+                if total_hops < 2 or total_hops > max_length:
+                    continue
+
+                # Stitch by dropping duplicated turning node.
+                roundtrip = tuple(outbound + inbound[1:])
+
+                # Enforce "once per leg" / "at most twice overall" semantics.
+                counts: dict[str, int] = {}
+                for node in roundtrip:
+                    counts[node] = counts.get(node, 0) + 1
+                if counts.get(origin, 0) != 2:
+                    continue
+                if any(node != origin and count > 2 for node, count in counts.items()):
+                    continue
+
+                found.add(roundtrip)
+
+    ordered = sorted(found, key=lambda p: (len(p), p))
+    if max_paths is not None:
+        return ordered[:max_paths]
+    return ordered
+
+
+def _load_metric(metric_file: str | Path) -> np.ndarray:
+    """Load the first data array of a metric GIFTI as a 1-D float array."""
+    return np.asarray(nib.load(str(metric_file)).darrays[0].data, dtype=np.float64)
+
+
+def roundtrip_metric(
+    graph: NeuromapsGraph,
+    metric_file: str | Path,
+    path: tuple[str, ...],
+    hemisphere: Literal["left", "right"],
+    workdir: str | Path,
+    *,
+    density: str | None = None,
+    add_edge: bool = False,
+) -> Path:
+    """Carry a metric hop-by-hop along ``path``, returning the final file.
+
+    Every consecutive pair in ``path`` is a direct edge, so each hop is a
+    single-hop resample performed by the production transformer
+    (:meth:`NeuromapsGraph.surface_to_surface_transformer`). The output of one
+    hop becomes the input of the next.
+
+    Args:
+        graph: Populated :class:`~neuromaps_prime.graph.NeuromapsGraph`.
+        metric_file: Seed metric GIFTI defined on the origin space.
+        path: Return path from :func:`find_return_paths`.
+        hemisphere: ``'left'`` or ``'right'``.
+        workdir: Directory for the per-hop intermediate metric files.
+        density: Fixed mesh density to use for every hop. When ``None`` the
+            transformer estimates the source density and resamples to each
+            target's highest available density.
+        add_edge: Whether the transformer may register composed transforms as
+            new edges. Off by default so the cycle test does not mutate the
+            graph it is measuring.
+
+    Returns:
+        Path to the metric after it has returned to the origin space.
+
+    Raises:
+        RuntimeError: If any hop cannot be resolved to a transform.
+    """
+    workdir = Path(workdir)
+    current = Path(metric_file)
+    path_token = _path_token(path)
+    for hop, (src, dst) in enumerate(pairwise(path)):
+        out_name = f"cycle_{path_token}_hop{hop:02d}_{src}-to-{dst}.func.gii"
+        result = graph.surface_to_surface_transformer(
+            transformer_type="metric",
+            input_file=current,
+            source_space=src,
+            target_space=dst,
+            hemisphere=hemisphere,
+            # Keep output path relative so dockerized wb_command writes inside
+            # its mounted output directory instead of an unmapped host path.
+            output_file_path=out_name,
+            source_density=density,
+            target_density=density,
+            add_edge=add_edge,
+        )
+        if result is None:
+            raise RuntimeError(
+                f"No surface transform for hop '{src}' -> '{dst}' "
+                f"on path {' -> '.join(path)}"
+            )
+        current = Path(result)
+    return current
+
+
+def score_roundtrip(
+    original_file: str | Path, roundtrip_file: str | Path
+) -> tuple[float, float]:
+    """Return ``(pearson_r, max_abs_diff)`` for an original vs round-tripped metric.
+
+    Args:
+        original_file: The seed metric on the origin space.
+        roundtrip_file: The metric after it has returned to the origin space.
+
+    Returns:
+        Tuple of the Pearson correlation and the maximum absolute vertex-wise
+        difference between the two metrics.
+
+        Pearson correlation is undefined when either metric is constant
+        (zero variance). For cycle-test sanity checks we return ``1.0`` when
+        both constant vectors are equal (treating matching NaNs as equal) and
+        ``0.0`` otherwise.
+
+    Raises:
+        ValueError: If the two metrics have different vertex counts (which means
+            the metric did not return to the origin mesh).
+    """
+    original = _load_metric(original_file)
+    roundtrip = _load_metric(roundtrip_file)
+    if original.shape != roundtrip.shape:
+        raise ValueError(
+            "Round-tripped metric did not return to the origin mesh: "
+            f"{roundtrip.shape} vs {original.shape}."
+        )
+    finite_mask = np.isfinite(original) & np.isfinite(roundtrip)
+    if np.any(finite_mask):
+        max_abs_diff = float(np.max(np.abs(original[finite_mask] - roundtrip[finite_mask])))
+    else:
+        max_abs_diff = float("nan")
+
+    vectors_equal = bool(np.allclose(original, roundtrip, equal_nan=True))
+    if np.count_nonzero(finite_mask) < 2:
+        pearson_r = 1.0 if vectors_equal else 0.0
+        return pearson_r, max_abs_diff
+
+    original_finite = original[finite_mask]
+    roundtrip_finite = roundtrip[finite_mask]
+    original_std = float(np.std(original_finite))
+    roundtrip_std = float(np.std(roundtrip_finite))
+    if np.isclose(original_std, 0.0) or np.isclose(roundtrip_std, 0.0):
+        pearson_r = 1.0 if vectors_equal else 0.0
+    else:
+        pearson_r = float(np.corrcoef(original_finite, roundtrip_finite)[0, 1])
+        if np.isnan(pearson_r) and vectors_equal:
+            pearson_r = 1.0
+
+    return pearson_r, max_abs_diff
+
+
+def run_cycle_test(
+    graph: NeuromapsGraph,
+    origin: str,
+    metric_file: str | Path,
+    hemisphere: Literal["left", "right"],
+    workdir: str | Path,
+    *,
+    density: str | None = None,
+    max_length: int | None = None,
+    output_file: str | Path | None = None,
+) -> list[CycleResult]:
+    """Round-trip ``metric_file`` around every return path from ``origin``.
+
+    Args:
+        graph: Populated :class:`~neuromaps_prime.graph.NeuromapsGraph`.
+        origin: Space the metric starts from and must return to.
+        metric_file: Seed metric GIFTI defined on the origin space.
+        hemisphere: ``'left'`` or ``'right'``.
+        workdir: Directory for intermediate metric files.
+        density: Fixed mesh density for every hop, or ``None`` to let the
+            transformer choose per hop (see :func:`roundtrip_metric`).
+        max_length: Optional cap on path length passed to
+            :func:`find_return_paths`.
+        output_file: Optional path to a text file where the results summary
+            will be saved. When ``None`` no file is written.
+
+    Returns:
+        One :class:`CycleResult` per return path, in enumeration order.
+    """
+    results: list[CycleResult] = []
+    for path in find_return_paths(graph, origin, max_length=max_length):
+        roundtrip = roundtrip_metric(
+            graph, metric_file, path, hemisphere, workdir, density=density
+        )
+        pearson_r, max_abs_diff = score_roundtrip(metric_file, roundtrip)
+        logger.info(
+            "cycle %s: r=%.6f max|delta|=%.3e",
+            " -> ".join(path),
+            pearson_r,
+            max_abs_diff,
+        )
+        results.append(
+            CycleResult(path=path, pearson_r=pearson_r, max_abs_diff=max_abs_diff)
+        )
+
+    # Print summary table to stdout.
+    header = f"{'Transformation path':<50}  {'Pearson r':>10}  {'Max |delta|':>14}"
+    separator = "-" * len(header)
+    print(separator)
+    print(header)
+    print(separator)
+    for r in results:
+        print(f"{r.label:<50}  {r.pearson_r:>10.6f}  {r.max_abs_diff:>14.3e}")
+    print(separator)
+    print(f"Total cycles: {len(results)}")
+
+    # Optionally save the same summary to a text file.
+    if output_file is not None:
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as fh:
+            fh.write(f"Cycle test results — origin: {origin}, hemisphere: {hemisphere}\n")
+            fh.write(separator + "\n")
+            fh.write(header + "\n")
+            fh.write(separator + "\n")
+            for r in results:
+                fh.write(
+                    f"{r.label:<50}  {r.pearson_r:>10.6f}  {r.max_abs_diff:>14.3e}\n"
+                )
+            fh.write(separator + "\n")
+            fh.write(f"Total cycles: {len(results)}\n")
+        logger.info("Cycle test results saved to %s", output_path)
+
+    return results

--- a/tests/regression/test_cycle.py
+++ b/tests/regression/test_cycle.py
@@ -1,0 +1,548 @@
+"""Cycle regression test on the real graph.
+
+Round-trips a synthetic surface metric around every return path from an origin
+space and reports the Pearson correlation between the original metric and each
+round-trip. High correlation means the transforms on that path compose close to
+the identity; lower correlation flags lower-quality paths.
+
+This is the deployed counterpart to the hermetic unit test in
+``tests/unit/test_cycle.py``. Both call the same machinery in
+``tests/regression/cycle.py``; the unit test proves that machinery returns
+r ~ 1 on a synthetic identity network, while this test measures the *real*
+transforms and therefore needs Workbench and network access (like
+``test_surf_matrix.py``).
+
+Edit ``ORIGIN``, ``LABEL``, and ``HEMISPHERE`` for the space/probe tag you want
+to test, then run::
+
+    pytest tests/regression/test_cycle.py -s
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from nibabel.gifti import GiftiDataArray, GiftiImage
+from matplotlib_surface_plotting import plot_surf
+
+from neuromaps_prime.graph import NeuromapsGraph
+from tests.neuromapsprime_unit_test.cycle import (
+    _path_token,
+    find_return_paths,
+    resolve_hop_transforms,
+    roundtrip_metric,
+    score_roundtrip,
+)
+
+logger = logging.getLogger(__name__)
+
+output_dir = Path(__file__).resolve().parent / "cycle_outputs"
+output_dir.mkdir(parents=True, exist_ok=True)
+
+# --- configure the probe ---------------------------------------------------- #
+ORIGINS = ["Yerkes19", "NMT2Sym", "D99"] #["fsLR", "Yerkes19"]
+LABEL = "RM_scalinghcp"
+HEMISPHERE = "left"
+# Bound path length so cycle enumeration stays tractable on the dense real
+# graph (number of simple cycles grows combinatorially).
+MAX_CYCLE_LENGTH = 4
+PLOT_MAX_VERTICES = 20000
+# Set to ``None`` to enumerate every path up to ``MAX_CYCLE_LENGTH``.
+MAX_PATHS: int | None = None
+# With non-mirrored multi-hop round-trips, many paths are expected to score
+# modestly. Guard against hard breakage by requiring at least one usable path.
+MIN_BEST_PEARSON = 0.05
+
+# Enable logging of wb_command calls for manual inspection/re-running
+LOG_COMMANDS = True
+
+
+class CommandLogHandler(logging.Handler):
+    """Capture niwrap/Styx command logs to a file."""
+
+    def __init__(self, log_file: Path):
+        super().__init__()
+        self.log_file = log_file
+        self.commands: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Capture log records that contain command information."""
+        # Styx logs full command strings in debug records
+        if "command" in record.getMessage().lower() or "wb_command" in record.name.lower():
+            self.commands.append(self.format(record))
+
+    def save(self) -> None:
+        """Write captured commands to file."""
+        if self.commands:
+            with self.log_file.open("w", encoding="utf-8") as f:
+                f.write("# wb_command calls used in this cycle\n")
+                f.write("# Run these to manually reproduce the transformations\n\n")
+                for cmd in self.commands:
+                    f.write(f"{cmd}\n")
+# graph (number of simple cycles grows combinatorially).
+MAX_CYCLE_LENGTH = 2
+PLOT_MAX_VERTICES = 20000
+# Set to ``None`` to enumerate every path up to ``MAX_CYCLE_LENGTH``.
+MAX_PATHS: int | None = None
+# With non-mirrored multi-hop round-trips, many paths are expected to score
+# modestly. Guard against hard breakage by requiring at least one usable path.
+MIN_BEST_PEARSON = 0.05
+
+
+def _load_surface_coords(surface_file: Path) -> np.ndarray:
+    """Load the ``(n_vertices, 3)`` world coordinates from a surface GIFTI."""
+    for darray in nib.load(str(surface_file)).darrays:
+        if darray.data.ndim == 2 and darray.data.shape[1] == 3:
+            return np.asarray(darray.data, dtype=np.float64)
+    raise ValueError(f"No pointset coordinates found in {surface_file}")
+
+
+def _load_surface_topology(surface_file: Path) -> np.ndarray:
+    """Load the ``(n_triangles, 3)`` triangle indices from a surface GIFTI."""
+    img = nib.load(str(surface_file))
+    # NIFTI_INTENT_TRIANGLE has integer code 1009. ``darray.intent`` is stored
+    # as the intent *name* string in nibabel, so match against both forms.
+    for darray in img.darrays:
+        if str(darray.intent) in ("NIFTI_INTENT_TRIANGLE", "1009"):
+            return np.asarray(darray.data, dtype=np.int32)
+    # Fallback: an integer-typed (N, 3) array is the triangle topology.
+    for darray in img.darrays:
+        data = np.asarray(darray.data)
+        if (
+            data.ndim == 2
+            and data.shape[1] == 3
+            and np.issubdtype(data.dtype, np.integer)
+        ):
+            return data.astype(np.int32)
+    raise ValueError(f"No triangle topology found in {surface_file}")
+
+
+def _extract_surface_mesh(surface_file: Path) -> tuple[np.ndarray, np.ndarray]:
+    """Extract (vertices, triangles) from a surface GIFTI file."""
+    return _load_surface_coords(surface_file), _load_surface_topology(surface_file)
+
+
+def _write_metric(metric_file: Path, values: np.ndarray) -> Path:
+    """Write one scalar value per vertex as a ``.func.gii`` metric file."""
+    image = GiftiImage(
+        darrays=[
+            GiftiDataArray(
+                np.asarray(values, dtype=np.float32),
+                intent="NIFTI_INTENT_NONE",
+            )
+        ]
+    )
+    nib.save(image, str(metric_file))
+    return metric_file
+
+
+def _make_xyz_product_metric(
+    graph: NeuromapsGraph,
+    origin: str,
+    label: str,
+    density: str,
+    hemisphere: str,
+    out_dir: Path,
+) -> Path:
+    """Create a synthetic metric where each vertex value is ``x*y*z``."""
+    sphere = graph.fetch_surface_atlas(
+        space=origin,
+        density=density,
+        hemisphere=hemisphere,
+        resource_type="sphere",
+    )
+    assert sphere is not None, (
+        f"No sphere atlas for {origin} at density '{density}' ({hemisphere})."
+    )
+    coords = _load_surface_coords(Path(sphere.fetch()))
+    values = np.prod(coords, axis=1)
+    metric_file = out_dir / f"metric_{origin}_{label}_{density}_{hemisphere}.func.gii"
+    return _write_metric(metric_file, values)
+
+
+def _load_metric_values(metric_file: Path) -> np.ndarray:
+    """Load metric values from the first data array in a metric GIFTI."""
+    return np.asarray(nib.load(str(metric_file)).darrays[0].data, dtype=np.float64)
+
+
+def _path_to_filename(path: tuple[str, ...]) -> str:
+    """Convert a cycle path tuple to a filesystem-friendly stem."""
+    digest = hashlib.sha1("->".join(path).encode("utf-8")).hexdigest()[:12]
+    return f"{path[0]}_to_{path[-1]}_{len(path) - 1}h_{digest}"
+
+
+def _plot_cycle_cortical_surfaces(
+    graph: NeuromapsGraph,
+    path: tuple[str, ...],
+    metrics_by_hop: list[tuple[str, np.ndarray]],
+    hemisphere: str,
+    pearson_r: float,
+    plot_dir: Path,
+) -> None:
+    """Create 2 images per node (midthickness + sphere) showing the metric.
+    
+    For a path like (Yerkes19, MEBRAINS, Yerkes19), creates 6 images:
+    - node0_Yerkes19_midthickness.png, node0_Yerkes19_sphere.png
+    - node1_MEBRAINS_midthickness.png, node1_MEBRAINS_sphere.png
+    - node2_Yerkes19_midthickness.png, node2_Yerkes19_sphere.png
+    
+    Args:
+        graph: Populated NeuromapsGraph for fetching surfaces.
+        path: Cycle path, e.g. ('Yerkes19', 'MEBRAINS', 'Yerkes19').
+        metrics_by_hop: List of (space_name, metric_values) for each node.
+        hemisphere: 'left' or 'right'.
+        pearson_r: Pearson correlation for the cycle.
+        plot_dir: Output directory for images.
+    """
+    if not metrics_by_hop:
+        return
+
+    path_token = _path_token(path)
+    path_label = " -> ".join(path)
+    
+    for hop_idx, (space, metric_values) in enumerate(metrics_by_hop):
+        # Get color scale from finite values
+        finite_mask = np.isfinite(metric_values)
+        if np.any(finite_mask):
+            vmin, vmax = np.percentile(metric_values[finite_mask], [2, 98])
+        else:
+            vmin, vmax = 0.0, 1.0
+        
+        # Plot midthickness surface
+        _plot_single_surface(
+            graph, space, metric_values, hemisphere,
+            "midthickness", float(vmin), float(vmax), plot_dir,
+            path_token, path_label, hop_idx, pearson_r,
+        )
+        
+
+
+
+def _find_matching_surface(
+    graph: NeuromapsGraph,
+    space: str,
+    hemisphere: str,
+    resource_type: str,
+    n_vertices: int,
+) -> tuple[object, str] | None:
+    """Return the (atlas, density) whose surface vertex count matches the metric.
+
+    Iterates over every registered atlas of ``resource_type`` for ``space`` and
+    returns the first whose vertex count equals ``n_vertices``. This avoids
+    guessing density from vertex count (which breaks across spaces with
+    non-standard meshes).
+    """
+    atlases = graph.utils.cache.get_surface_atlases(
+        space=space,
+        hemisphere=hemisphere,
+        resource_type=resource_type,
+    )
+    for atlas in atlases:
+        try:
+            coords = _load_surface_coords(Path(atlas.fetch()))
+        except (ValueError, FileNotFoundError, OSError):
+            continue
+        if coords.shape[0] == n_vertices:
+            return atlas, atlas.density
+    return None
+
+
+def _plot_single_surface(
+    graph: NeuromapsGraph,
+    space: str,
+    metric_values: np.ndarray,
+    hemisphere: str,
+    resource_type: str,
+    vmin: float,
+    vmax: float,
+    plot_dir: Path,
+    path_token: str,
+    path_label: str,
+    hop_idx: int,
+    pearson_r: float,
+) -> None:
+    """Plot a single surface (midthickness or sphere) for one node.
+
+    The surface is selected by matching its vertex count to the metric so the
+    overlay always aligns. Failures are logged as warnings (never silent) so
+    missing surfaces are visible in the test output.
+    """
+    n_vertices = metric_values.shape[0]
+    match = _find_matching_surface(
+        graph, space, hemisphere, resource_type, n_vertices
+    )
+    if match is None:
+        logger.warning(
+            "No %s surface for %s (%s) matching %d vertices; skipping plot.",
+            resource_type, space, hemisphere, n_vertices,
+        )
+        return
+
+    surface_file, density = match
+    try:
+        coords, faces = _extract_surface_mesh(Path(surface_file.fetch()))
+    except Exception as e:
+        logger.warning(
+            "Failed to load %s mesh for %s (%s): %s",
+            resource_type, space, density, e,
+        )
+        return
+
+    output_path = plot_dir / f"{path_token}_node{hop_idx:02d}_{space}_{resource_type}.png"
+    try:
+        plot_surf(
+            coords, faces, metric_values,
+            rotate=[270, 0],  # Lateral view
+            filename=str(output_path),
+            vmin=vmin, vmax=vmax,
+            cmap="viridis",
+            title=f"{path_label}\n{space} | r={pearson_r:.5f}",
+        )
+        logger.info("Saved: %s", output_path.name)
+    except Exception as e:
+        logger.warning(
+            "plot_surf failed for %s %s (%s): %s",
+            space, resource_type, density, e,
+        )
+    finally:
+        # plot_surf leaves figures open; close them to avoid memory buildup.
+        plt.close("all")
+
+
+def test_cycle_roundtrip(tmp_path: Path) -> None:
+    """Round-trip a synthetic metric through every return path and log correlations."""
+    for origin in ORIGINS:
+        logging.info(f"\n=== CYCLE ROUND-TRIP TEST: {origin} ===")
+        cycle_roundtrip(tmp_path, origin)
+
+
+def _roundtrip_with_intermediates(
+    graph: NeuromapsGraph,
+    metric_file: Path,
+    path: tuple[str, ...],
+    hemisphere: str,
+    workdir: Path,
+    density: str | None = None,
+) -> tuple[Path, list[tuple[str, np.ndarray]]]:
+    """Round-trip metric and collect intermediate values at each hop.
+    
+    The transformer auto-estimates source and target densities from the
+    metric file at each hop, allowing each space to use its native density.
+    
+    Returns:
+        (final_file, [(space, metric_values), ...])
+    """
+    from itertools import pairwise
+    
+    metrics: list[tuple[str, np.ndarray]] = []
+    current = Path(metric_file)
+    
+    for hop, (src, dst) in enumerate(pairwise(path)):
+        # Let transformer auto-estimate both source and target densities.
+        # This allows each space to use its native density rather than
+        # forcing the origin's density everywhere.
+        result = graph.surface_to_surface_transformer(
+            transformer_type="metric",
+            input_file=current,
+            source_space=src,
+            target_space=dst,
+            hemisphere=hemisphere,
+            output_file_path=f"cycle_intermediate_hop{hop:02d}_{src}-to-{dst}.func.gii",
+            source_density=None,  # Auto-estimate
+            target_density=None,  # Auto-estimate
+            add_edge=False,
+        )
+        if result is None:
+            raise RuntimeError(
+                f"No surface transform for hop '{src}' -> '{dst}' "
+                f"on path {' -> '.join(path)}"
+            )
+        current = Path(result)
+        # Collect metric at this hop's destination
+        metric_values = _load_metric_values(current)
+        metrics.append((dst, metric_values))
+    
+    return current, metrics
+
+
+def cycle_roundtrip(tmp_path: Path, origin: str) -> None:
+    """Round-trip a synthetic metric through every return path and log correlations."""
+    logging.basicConfig(level=logging.INFO)
+    graph = NeuromapsGraph()
+
+    # Set up command logging if enabled
+    cmd_log_handler = None
+    if LOG_COMMANDS:
+        cmd_log_handler = CommandLogHandler(tmp_path / "wb_commands.log")
+        # Capture niwrap/Styx logs
+        niwrap_logger = logging.getLogger("niwrap")
+        niwrap_logger.addHandler(cmd_log_handler)
+        niwrap_logger.setLevel(logging.DEBUG)
+        styx_logger = logging.getLogger("styx")
+        styx_logger.addHandler(cmd_log_handler)
+        styx_logger.setLevel(logging.DEBUG)
+
+    # Seed the metric at the origin's highest density so the round-trip returns
+    # to a matching mesh, then score every return path.
+    density = graph.find_highest_density(origin)
+    metric_file = _make_xyz_product_metric(
+        graph=graph,
+        origin=origin,
+        label=LABEL,
+        density=density,
+        hemisphere=HEMISPHERE,
+        out_dir=tmp_path,
+    )
+
+    paths = find_return_paths(
+        graph,
+        origin,
+        max_length=MAX_CYCLE_LENGTH,
+        allow_revisits=True,
+        max_paths=MAX_PATHS,
+    )
+
+    logger.info("Found %d return paths from %s", len(paths), origin)
+    assert paths, f"No return paths from '{origin}' on the surface layer."
+
+    sphere = graph.fetch_surface_atlas(
+        space=origin,
+        density=density,
+        hemisphere=HEMISPHERE,
+        resource_type="sphere",
+    )
+    assert sphere is not None, (
+        f"No sphere atlas for {origin} at density '{density}' ({HEMISPHERE})."
+    )
+    origin_coords = _load_surface_coords(Path(sphere.fetch()))
+    original_metric = _load_metric_values(metric_file)
+    assert origin_coords.shape[0] == original_metric.shape[0], (
+        "Origin sphere vertex count does not match seed metric length: "
+        f"{origin_coords.shape[0]} vs {original_metric.shape[0]}"
+    )
+
+    plot_dir = output_dir / f"cycle_{origin}_{LABEL}_{HEMISPHERE}_plots"
+    plot_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict[str, str | int | float]] = []
+    for path in paths:
+        # Use the intermediate metric collector for better visualization
+        roundtrip_file, intermediates = _roundtrip_with_intermediates(
+            graph,
+            metric_file,
+            path,
+            HEMISPHERE,
+            tmp_path,
+            density=density,
+        )
+        
+        pearson_r, max_abs_diff = score_roundtrip(metric_file, roundtrip_file)
+
+        path_label = " -> ".join(path)
+
+        # Write a CSV listing every transform file used for this cycle path.
+        # Note: with auto-estimated densities, the fixed density passed here
+        # may not match what was actually used. This is just for reference.
+        try:
+            transform_rows = resolve_hop_transforms(
+                graph, path, HEMISPHERE, density
+            )
+            xfm_csv = plot_dir / f"{_path_to_filename(path)}_transforms.csv"
+            with xfm_csv.open("w", encoding="utf-8") as fh:
+                fh.write("source_space,target_space,density,filepath\n")
+                for src, dst, den, fpath in transform_rows:
+                    fh.write(f"{src},{dst},{den},{fpath}\n")
+        except Exception as e:
+            logger.warning(f"Could not resolve transform files for cycle {path_label}: {e}")
+
+        # Save per-node surface visualizations (midthickness + sphere for each
+        # space visited). Prepend the origin/original metric so node 0 is the
+        # starting point and the final node is the round-tripped result.
+        try:
+            all_metrics = [(path[0], original_metric)] + intermediates
+            _plot_cycle_cortical_surfaces(
+                graph=graph,
+                path=path,
+                metrics_by_hop=all_metrics,
+                hemisphere=HEMISPHERE,
+                pearson_r=pearson_r,
+                plot_dir=plot_dir,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to create surface plots: {e}")
+
+        rows.append(
+            {
+                "path": path_label,
+                "n_hops": len(path) - 1,
+                "pearson_r": pearson_r,
+                "max_abs_diff": max_abs_diff,
+            }
+        )
+
+    frame = pd.DataFrame(rows).sort_values("pearson_r", ascending=False)
+
+    logger.info("\n=== CYCLE TEST (%s, %s, %s) ===", origin, LABEL, HEMISPHERE)
+    logger.info("\n%s", frame.to_string(index=False))
+
+    csv_path = output_dir / f"cycle_{origin}_{LABEL}_{HEMISPHERE}.csv"
+    frame.to_csv(csv_path, index=False)
+    logger.info("Saved CSV -> %s", csv_path)
+    logger.info("Saved per-path plots -> %s", plot_dir)
+
+    # Print a formatted summary table to stdout.
+    col_path = max(len(r["path"]) for r in rows) if rows else 50
+    col_path = max(col_path, len("Transformation path"))
+    header = f"{'Transformation path':<{col_path}}  {'Hops':>4}  {'Pearson r':>10}  {'Max |delta|':>14}"
+    separator = "-" * len(header)
+    print(f"\n=== CYCLE TEST — {origin} | {LABEL} | {HEMISPHERE} ===")
+    print(separator)
+    print(header)
+    print(separator)
+    for _, row in frame.iterrows():
+        print(
+            f"{row['path']:<{col_path}}  {int(row['n_hops']):>4}  "
+            f"{row['pearson_r']:>10.6f}  {row['max_abs_diff']:>14.3e}"
+        )
+    print(separator)
+    print(f"Total cycles: {len(rows)}")
+
+    # Save the same table to a text file alongside the CSV.
+    txt_path = output_dir / f"cycle_{origin}_{LABEL}_{HEMISPHERE}.txt"
+    with txt_path.open("w", encoding="utf-8") as fh:
+        fh.write(f"Cycle test results — origin: {origin}, label: {LABEL}, hemisphere: {HEMISPHERE}\n")
+        fh.write(separator + "\n")
+        fh.write(header + "\n")
+        fh.write(separator + "\n")
+        for _, row in frame.iterrows():
+            fh.write(
+                f"{row['path']:<{col_path}}  {int(row['n_hops']):>4}  "
+                f"{row['pearson_r']:>10.6f}  {row['max_abs_diff']:>14.3e}\n"
+            )
+        fh.write(separator + "\n")
+        fh.write(f"Total cycles: {len(rows)}\n")
+    logger.info("Saved TXT summary -> %s", txt_path)
+
+    # Save command log if it was set up
+    if cmd_log_handler is not None:
+        cmd_log_handler.save()
+        logger.info("Saved wb_command log -> %s", cmd_log_handler.log_file)
+
+    # Under non-mirrored, multi-hop round-trips some low-scoring paths are
+    # expected; fail only on clearly broken output (non-finite scores or no
+    # minimally correlated route).
+    assert np.isfinite(frame["pearson_r"]).all(), (
+        "At least one path produced a non-finite Pearson r - inspect "
+        f"{csv_path}."
+    )
+    best_r = float(frame["pearson_r"].max())
+    assert best_r > MIN_BEST_PEARSON, (
+        f"Best round-trip correlation is too low (r={best_r:.6f}); inspect "
+        f"the generated reports in {plot_dir} and metrics in {csv_path}."
+    )

--- a/tests/regression/test_cycle.py
+++ b/tests/regression/test_cycle.py
@@ -12,7 +12,13 @@ r ~ 1 on a synthetic identity network, while this test measures the *real*
 transforms and therefore needs Workbench and network access (like
 ``test_surf_matrix.py``).
 
-Edit ``ORIGIN``, ``LABEL``, and ``HEMISPHERE`` for the space/probe tag you want
+Artifacts are written to a run-specific directory under
+``tests/regression/cycle_outputs_<random_suffix>/`` so repeated runs do not
+overwrite each other. Surface resampling prefers ``midthickness`` area
+surfaces, then falls back to ``pial`` and ``white`` when required resources
+are missing for a space/hemisphere.
+
+Edit ``ORIGINS``, ``LABEL``, and ``HEMISPHERES`` for the space/probe tags you want
 to test, then run::
 
     pytest tests/regression/test_cycle.py -s
@@ -22,6 +28,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import secrets
+import shutil
 from pathlib import Path
 
 import nibabel as nib
@@ -36,19 +44,21 @@ from tests.neuromapsprime_unit_test.cycle import (
     _path_token,
     find_return_paths,
     resolve_hop_transforms,
-    roundtrip_metric,
     score_roundtrip,
 )
 
 logger = logging.getLogger(__name__)
 
-output_dir = Path(__file__).resolve().parent / "cycle_outputs"
+_RUN_SUFFIX = secrets.token_hex(4)
+# Keep every test run isolated to simplify debugging and avoid clobbering artifacts.
+output_dir = Path(__file__).resolve().parent / f"cycle_outputs_{_RUN_SUFFIX}"
 output_dir.mkdir(parents=True, exist_ok=True)
 
 # --- configure the probe ---------------------------------------------------- #
-ORIGINS = ["Yerkes19", "NMT2Sym", "D99"] #["fsLR", "Yerkes19"]
+# Set to ``None`` to auto-populate from all graph coordinate spaces.
+ORIGINS: list[str] | None = None
 LABEL = "RM_scalinghcp"
-HEMISPHERE = "left"
+HEMISPHERES = ("left", "right")
 # Bound path length so cycle enumeration stays tractable on the dense real
 # graph (number of simple cycles grows combinatorially).
 MAX_CYCLE_LENGTH = 4
@@ -85,14 +95,6 @@ class CommandLogHandler(logging.Handler):
                 f.write("# Run these to manually reproduce the transformations\n\n")
                 for cmd in self.commands:
                     f.write(f"{cmd}\n")
-# graph (number of simple cycles grows combinatorially).
-MAX_CYCLE_LENGTH = 2
-PLOT_MAX_VERTICES = 20000
-# Set to ``None`` to enumerate every path up to ``MAX_CYCLE_LENGTH``.
-MAX_PATHS: int | None = None
-# With non-mirrored multi-hop round-trips, many paths are expected to score
-# modestly. Guard against hard breakage by requiring at least one usable path.
-MIN_BEST_PEARSON = 0.05
 
 
 def _load_surface_coords(surface_file: Path) -> np.ndarray:
@@ -317,9 +319,11 @@ def _plot_single_surface(
 
 def test_cycle_roundtrip(tmp_path: Path) -> None:
     """Round-trip a synthetic metric through every return path and log correlations."""
-    for origin in ORIGINS:
-        logging.info(f"\n=== CYCLE ROUND-TRIP TEST: {origin} ===")
-        cycle_roundtrip(tmp_path, origin)
+    origins = ORIGINS or sorted(NeuromapsGraph().nodes)
+    for origin in origins:
+        for hemisphere in HEMISPHERES:
+            logging.info(f"\n=== CYCLE ROUND-TRIP TEST: {origin} ({hemisphere}) ===")
+            cycle_roundtrip(tmp_path, origin, hemisphere)
 
 
 def _roundtrip_with_intermediates(
@@ -328,8 +332,7 @@ def _roundtrip_with_intermediates(
     path: tuple[str, ...],
     hemisphere: str,
     workdir: Path,
-    density: str | None = None,
-) -> tuple[Path, list[tuple[str, np.ndarray]]]:
+) -> tuple[Path, list[tuple[str, np.ndarray]]] | None:
     """Round-trip metric and collect intermediate values at each hop.
     
     The transformer auto-estimates source and target densities from the
@@ -342,28 +345,61 @@ def _roundtrip_with_intermediates(
     
     metrics: list[tuple[str, np.ndarray]] = []
     current = Path(metric_file)
+    workdir.mkdir(parents=True, exist_ok=True)
     
     for hop, (src, dst) in enumerate(pairwise(path)):
         # Let transformer auto-estimate both source and target densities.
         # This allows each space to use its native density rather than
         # forcing the origin's density everywhere.
-        result = graph.surface_to_surface_transformer(
-            transformer_type="metric",
-            input_file=current,
-            source_space=src,
-            target_space=dst,
-            hemisphere=hemisphere,
-            output_file_path=f"cycle_intermediate_hop{hop:02d}_{src}-to-{dst}.func.gii",
-            source_density=None,  # Auto-estimate
-            target_density=None,  # Auto-estimate
-            add_edge=False,
-        )
+        # Use a relative output name so Workbench writes inside Styx's mounted
+        # output dir, then copy into our run-specific artifact directory.
+        hop_name = f"cycle_intermediate_hop{hop:02d}_{src}-to-{dst}.func.gii"
+        hop_target = workdir / hop_name
+        result = None
+        last_error: Exception | None = None
+        for area_resource in ("midthickness", "pial", "white"):
+            try:
+                result = graph.surface_to_surface_transformer(
+                    transformer_type="metric",
+                    input_file=current,
+                    source_space=src,
+                    target_space=dst,
+                    hemisphere=hemisphere,
+                    output_file_path=hop_name,
+                    source_density=None,  # Auto-estimate
+                    target_density=None,  # Auto-estimate
+                    area_resource=area_resource,
+                    add_edge=False,
+                )
+                if result is not None:
+                    if area_resource != "midthickness":
+                        logger.info(
+                            "Using fallback area surface '%s' for hop '%s' -> '%s' (%s).",
+                            area_resource,
+                            src,
+                            dst,
+                            hemisphere,
+                        )
+                    break
+            except Exception as e:
+                last_error = e
+                continue
         if result is None:
-            raise RuntimeError(
-                f"No surface transform for hop '{src}' -> '{dst}' "
-                f"on path {' -> '.join(path)}"
+            logger.warning(
+                "Skipping path %s for hemisphere %s at hop '%s' -> '%s': %s",
+                " -> ".join(path),
+                hemisphere,
+                src,
+                dst,
+                last_error,
             )
-        current = Path(result)
+            return None
+        result_path = Path(result)
+        if result_path.resolve() != hop_target.resolve():
+            shutil.copy2(result_path, hop_target)
+            current = hop_target
+        else:
+            current = result_path
         # Collect metric at this hop's destination
         metric_values = _load_metric_values(current)
         metrics.append((dst, metric_values))
@@ -371,15 +407,17 @@ def _roundtrip_with_intermediates(
     return current, metrics
 
 
-def cycle_roundtrip(tmp_path: Path, origin: str) -> None:
+def cycle_roundtrip(tmp_path: Path, origin: str, hemisphere: str) -> None:
     """Round-trip a synthetic metric through every return path and log correlations."""
     logging.basicConfig(level=logging.INFO)
     graph = NeuromapsGraph()
+    work_dir = output_dir / f"work_{origin}_{hemisphere}"
+    work_dir.mkdir(parents=True, exist_ok=True)
 
     # Set up command logging if enabled
     cmd_log_handler = None
     if LOG_COMMANDS:
-        cmd_log_handler = CommandLogHandler(tmp_path / "wb_commands.log")
+        cmd_log_handler = CommandLogHandler(work_dir / "wb_commands.log")
         # Capture niwrap/Styx logs
         niwrap_logger = logging.getLogger("niwrap")
         niwrap_logger.addHandler(cmd_log_handler)
@@ -391,14 +429,23 @@ def cycle_roundtrip(tmp_path: Path, origin: str) -> None:
     # Seed the metric at the origin's highest density so the round-trip returns
     # to a matching mesh, then score every return path.
     density = graph.find_highest_density(origin)
-    metric_file = _make_xyz_product_metric(
-        graph=graph,
-        origin=origin,
-        label=LABEL,
-        density=density,
-        hemisphere=HEMISPHERE,
-        out_dir=tmp_path,
-    )
+    try:
+        metric_file = _make_xyz_product_metric(
+            graph=graph,
+            origin=origin,
+            label=LABEL,
+            density=density,
+            hemisphere=hemisphere,
+            out_dir=work_dir,
+        )
+    except AssertionError as e:
+        logger.warning(
+            "Skipping %s (%s): could not seed origin metric: %s",
+            origin,
+            hemisphere,
+            e,
+        )
+        return
 
     paths = find_return_paths(
         graph,
@@ -409,38 +456,56 @@ def cycle_roundtrip(tmp_path: Path, origin: str) -> None:
     )
 
     logger.info("Found %d return paths from %s", len(paths), origin)
-    assert paths, f"No return paths from '{origin}' on the surface layer."
+    if not paths:
+        logger.warning(
+            "No return paths from %s on the surface layer; skipping hemisphere %s.",
+            origin,
+            hemisphere,
+        )
+        return
 
     sphere = graph.fetch_surface_atlas(
         space=origin,
         density=density,
-        hemisphere=HEMISPHERE,
+        hemisphere=hemisphere,
         resource_type="sphere",
     )
-    assert sphere is not None, (
-        f"No sphere atlas for {origin} at density '{density}' ({HEMISPHERE})."
-    )
+    if sphere is None:
+        logger.warning(
+            "No sphere atlas for %s at density '%s' (%s); skipping.",
+            origin,
+            density,
+            hemisphere,
+        )
+        return
     origin_coords = _load_surface_coords(Path(sphere.fetch()))
     original_metric = _load_metric_values(metric_file)
-    assert origin_coords.shape[0] == original_metric.shape[0], (
-        "Origin sphere vertex count does not match seed metric length: "
-        f"{origin_coords.shape[0]} vs {original_metric.shape[0]}"
-    )
+    if origin_coords.shape[0] != original_metric.shape[0]:
+        logger.warning(
+            "Skipping %s (%s): origin sphere/metric size mismatch (%d vs %d).",
+            origin,
+            hemisphere,
+            origin_coords.shape[0],
+            original_metric.shape[0],
+        )
+        return
 
-    plot_dir = output_dir / f"cycle_{origin}_{LABEL}_{HEMISPHERE}_plots"
+    plot_dir = output_dir / f"cycle_{origin}_{LABEL}_{hemisphere}_plots"
     plot_dir.mkdir(parents=True, exist_ok=True)
 
     rows: list[dict[str, str | int | float]] = []
     for path in paths:
         # Use the intermediate metric collector for better visualization
-        roundtrip_file, intermediates = _roundtrip_with_intermediates(
+        roundtrip_result = _roundtrip_with_intermediates(
             graph,
             metric_file,
             path,
-            HEMISPHERE,
-            tmp_path,
-            density=density,
+            hemisphere,
+            work_dir,
         )
+        if roundtrip_result is None:
+            continue
+        roundtrip_file, intermediates = roundtrip_result
         
         pearson_r, max_abs_diff = score_roundtrip(metric_file, roundtrip_file)
 
@@ -451,7 +516,7 @@ def cycle_roundtrip(tmp_path: Path, origin: str) -> None:
         # may not match what was actually used. This is just for reference.
         try:
             transform_rows = resolve_hop_transforms(
-                graph, path, HEMISPHERE, density
+                graph, path, hemisphere, density
             )
             xfm_csv = plot_dir / f"{_path_to_filename(path)}_transforms.csv"
             with xfm_csv.open("w", encoding="utf-8") as fh:
@@ -470,7 +535,7 @@ def cycle_roundtrip(tmp_path: Path, origin: str) -> None:
                 graph=graph,
                 path=path,
                 metrics_by_hop=all_metrics,
-                hemisphere=HEMISPHERE,
+                hemisphere=hemisphere,
                 pearson_r=pearson_r,
                 plot_dir=plot_dir,
             )
@@ -486,12 +551,20 @@ def cycle_roundtrip(tmp_path: Path, origin: str) -> None:
             }
         )
 
+    if not rows:
+        logger.warning(
+            "No valid round-trip paths for %s (%s); likely missing hemisphere-specific resources.",
+            origin,
+            hemisphere,
+        )
+        return
+
     frame = pd.DataFrame(rows).sort_values("pearson_r", ascending=False)
 
-    logger.info("\n=== CYCLE TEST (%s, %s, %s) ===", origin, LABEL, HEMISPHERE)
+    logger.info("\n=== CYCLE TEST (%s, %s, %s) ===", origin, LABEL, hemisphere)
     logger.info("\n%s", frame.to_string(index=False))
 
-    csv_path = output_dir / f"cycle_{origin}_{LABEL}_{HEMISPHERE}.csv"
+    csv_path = output_dir / f"cycle_{origin}_{LABEL}_{hemisphere}.csv"
     frame.to_csv(csv_path, index=False)
     logger.info("Saved CSV -> %s", csv_path)
     logger.info("Saved per-path plots -> %s", plot_dir)
@@ -501,7 +574,7 @@ def cycle_roundtrip(tmp_path: Path, origin: str) -> None:
     col_path = max(col_path, len("Transformation path"))
     header = f"{'Transformation path':<{col_path}}  {'Hops':>4}  {'Pearson r':>10}  {'Max |delta|':>14}"
     separator = "-" * len(header)
-    print(f"\n=== CYCLE TEST — {origin} | {LABEL} | {HEMISPHERE} ===")
+    print(f"\n=== CYCLE TEST — {origin} | {LABEL} | {hemisphere} ===")
     print(separator)
     print(header)
     print(separator)
@@ -514,9 +587,9 @@ def cycle_roundtrip(tmp_path: Path, origin: str) -> None:
     print(f"Total cycles: {len(rows)}")
 
     # Save the same table to a text file alongside the CSV.
-    txt_path = output_dir / f"cycle_{origin}_{LABEL}_{HEMISPHERE}.txt"
+    txt_path = output_dir / f"cycle_{origin}_{LABEL}_{hemisphere}.txt"
     with txt_path.open("w", encoding="utf-8") as fh:
-        fh.write(f"Cycle test results — origin: {origin}, label: {LABEL}, hemisphere: {HEMISPHERE}\n")
+        fh.write(f"Cycle test results — origin: {origin}, label: {LABEL}, hemisphere: {hemisphere}\n")
         fh.write(separator + "\n")
         fh.write(header + "\n")
         fh.write(separator + "\n")

--- a/uv.lock
+++ b/uv.lock
@@ -902,6 +902,19 @@ wheels = [
 ]
 
 [[package]]
+name = "matplotlib-surface-plotting"
+version = "0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "nibabel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/00/0d0c33489128c5d84c8ac55985c380310e843f17524c739bced4afabdf31/matplotlib_surface_plotting-0.14.tar.gz", hash = "sha256:b01f21309e82223d3d12921a54658529dc2b1781f7696818ec1fae8fe6046795", size = 15557, upload-time = "2025-07-25T09:13:02.929Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/a8/f43a1fe6cc79261397996e8969794d844a9a70a402cf23806e9af30dc71c/matplotlib_surface_plotting-0.14-py3-none-any.whl", hash = "sha256:3292bbe211bc37acc91938b78d738d0749465ef04072f71f3f69276b246d3597", size = 14629, upload-time = "2025-07-25T09:13:01.812Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1006,6 +1019,7 @@ docs = [
     { name = "pdoc" },
 ]
 tests = [
+    { name = "matplotlib-surface-plotting" },
     { name = "pandas" },
 ]
 validate = [
@@ -1040,7 +1054,10 @@ dev = [
     { name = "types-requests", specifier = ">=2.33.0.20260518" },
 ]
 docs = [{ name = "pdoc", specifier = ">=15.0.4" }]
-tests = [{ name = "pandas", specifier = ">=3.0.3" }]
+tests = [
+    { name = "matplotlib-surface-plotting", specifier = ">=0.1.0" },
+    { name = "pandas", specifier = ">=3.0.3" },
+]
 validate = [{ name = "check-jsonschema", specifier = ">=0.37.1" }]
 
 [[package]]
@@ -2151,7 +2168,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2233,7 +2250,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [


### PR DESCRIPTION
# PR Overview
This branch adds end-to-end cycle regression testing on the real Neuromaps graph to validate transform roundtrip quality across multi-hop paths.

#What’s included
1. New real-graph cycle regression tests
* Enumerate return paths from origin spaces
* Run hop-by-hop surface roundtrips
* Score path quality (Pearson r, max absolute difference)
2 . Artifact generation for debugging
* Per-run output folders with random suffixes
* CSV/TXT summaries and per-path transform manifests
* Surface plots and optional wb_command logs
3 Robust execution across real data variability
* Runs both left and right hemispheres
* Falls back for area surfaces in order:
** midthickness
** pial
** white
* Skips unusable paths/resources with clear warnings instead of hard-failing whole runs
Container-safe output handling
4. Adds an additional dependency, matplotlib_surface_plotting, for visual QC artifacts. 
