### PR TITLE
D99 rhemap surfaces

### DIFF
--- a/src/neuromaps_prime/resources/nodes/macaque/D99.yaml
+++ b/src/neuromaps_prime/resources/nodes/macaque/D99.yaml
@@ -19,6 +19,19 @@ D99:
       white:
         left: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d52303cc9143f354902958?view_only=b214f40525fe44b5bea3103478d08d0d
         right: https://files.osf.io/v1/resources/nmxfh/providers/osfstorage/69d523022882bdb2bc3ebdee?view_only=b214f40525fe44b5bea3103478d08d0d
+    168k:
+      midthickness:
+        left: https://github.com/HumanBrainED/RheMAP-Surf/blob/v1.0/surfaces/lh.D99.mid.surf.gii
+        right: https://github.com/HumanBrainED/RheMAP-Surf/blob/v1.0/surfaces/rh.D99.mid.surf.gii
+      pial:
+        left: https://github.com/HumanBrainED/RheMAP-Surf/blob/v1.0/surfaces/lh.D99.pial.surf.gii
+        right: https://github.com/HumanBrainED/RheMAP-Surf/blob/v1.0/surfaces/rh.D99.pial.surf.gii
+      sphere:
+        left: https://github.com/HumanBrainED/RheMAP-Surf/blob/v1.0/surfaces/lh.D99.sphere.surf.gii
+        right: https://github.com/HumanBrainED/RheMAP-Surf/blob/v1.0/surfaces/rh.D99.sphere.surf.gii
+      white:
+        left: https://github.com/HumanBrainED/RheMAP-Surf/blob/v1.0/surfaces/lh.D99.wm.surf.gii
+        right: https://github.com/HumanBrainED/RheMAP-Surf/blob/v1.0/surfaces/rh.D99.wm.surf.gii
 
   volumes:
     250um:


### PR DESCRIPTION
## This PR:
https://github.com/HumanBrainED/RheMAP-Surf/tree/v1.0/surfaces provides additional higher resolution input surfaces (168k) for D99, so I've included the paths here.

## Type of Change
- [ ] Bug fix
- [ ] Enhancement
- [x] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)
- #206 by @tamsinrogers 