### PR TITLE
feat: add surface mesh geometry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
   "scipy>=1.17.0",
   "requests>=2.34.2",
   "platformdirs>=4.10.0",
-  "styxpodman>=0.2.0"
+  "styxpodman>=0.2.0",
+  "joblib>=1.5.3"
 ]
 
 [dependency-groups]

--- a/src/neuromaps_prime/analysis/surfaces/__init__.py
+++ b/src/neuromaps_prime/analysis/surfaces/__init__.py
@@ -1,0 +1,8 @@
+"""Surface-specific operations for cortical mesh analysis.
+
+Contains tools for vertex-level geometry (mesh adjacency graphs, geodesic
+distance computation, parcel centroids) and surface-based null model
+generation (spin permutations, surrogate creation). Complements the
+space-agnostic statistics in :mod:`neuromaps_prime.analysis.stats` with
+operations that require surface topology.
+"""

--- a/src/neuromaps_prime/analysis/surfaces/__init__.py
+++ b/src/neuromaps_prime/analysis/surfaces/__init__.py
@@ -7,6 +7,9 @@ space-agnostic statistics in :mod:`neuromaps_prime.analysis.stats` with
 operations that require surface topology.
 """
 
-from neuromaps_prime.analysis.surfaces.points import make_surf_graph
+from neuromaps_prime.analysis.surfaces.points import (
+    get_surface_distance,
+    make_surf_graph,
+)
 
 __all__ = ["get_surface_distance", "make_surf_graph"]

--- a/src/neuromaps_prime/analysis/surfaces/__init__.py
+++ b/src/neuromaps_prime/analysis/surfaces/__init__.py
@@ -9,4 +9,4 @@ operations that require surface topology.
 
 from neuromaps_prime.analysis.surfaces.points import make_surf_graph
 
-__all__ = ["make_surf_graph"]
+__all__ = ["get_surface_distance", "make_surf_graph"]

--- a/src/neuromaps_prime/analysis/surfaces/__init__.py
+++ b/src/neuromaps_prime/analysis/surfaces/__init__.py
@@ -6,3 +6,7 @@ generation (spin permutations, surrogate creation). Complements the
 space-agnostic statistics in :mod:`neuromaps_prime.analysis.stats` with
 operations that require surface topology.
 """
+
+from neuromaps_prime.analysis.surfaces.points import make_surf_graph
+
+__all__ = ["make_surf_graph"]

--- a/src/neuromaps_prime/analysis/surfaces/points.py
+++ b/src/neuromaps_prime/analysis/surfaces/points.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+from scipy import sparse
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
+
+__all__ = ["make_surf_graph"]
 
 
 def _get_edges(faces: ArrayLike) -> np.ndarray:
@@ -269,3 +272,61 @@ def get_shared_triangles(faces: ArrayLike) -> dict[tuple[int, int], np.ndarray]:
     triplets[:, :, 2] = opposite
 
     return dict(zip(map(tuple, shared_edges), triplets, strict=True))
+
+
+def make_surf_graph(
+    vertices: ArrayLike,
+    faces: ArrayLike,
+    mask: ArrayLike | None = None,
+) -> sparse.csr_matrix:
+    """Build a sparse adjacency graph from a triangular surface mesh.
+
+    Combines direct edges (shared between two vertices of a face) with
+    indirect edges (connecting opposite vertices of adjacent triangles)
+    into a single sparse matrix.  Edge weights are the Euclidean length
+    of direct edges and the approximated geodesic distance of indirect
+    edges.  The resulting graph is suitable for Dijkstra-based shortest-
+    path distance computation on the surface.
+
+    Args:
+        vertices: Array of shape ``(n_vertices, 3)`` containing the
+            3-D coordinates of every mesh vertex.
+        faces: Array of shape ``(n_faces, 3)`` where each row contains
+            vertex indices that define a triangular face.
+        mask: Boolean array of shape ``(n_vertices,)``. If provided,
+            edges touching any ``True`` vertex are excluded from the
+            graph.
+
+    Returns:
+        A sparse CSR matrix of shape ``(n_vertices, n_vertices)`` where
+        non-zero entries are the edge weights between connected vertices.
+
+    Raises:
+        ValueError: If *mask* is provided and has a different length
+            than *vertices*.
+    """
+    vertices = np.asarray(vertices)
+    faces = np.asarray(faces)
+
+    if mask is not None:
+        mask = np.asarray(mask)
+        if len(mask) != len(vertices):
+            raise ValueError(
+                "Supplied mask and vertices array have different number "
+                f"of vertices ({len(mask)} != {len(vertices)})"
+            )
+
+    direct_edges, direct_weights = get_directed_edges(vertices, faces)
+    indirect_edges, indirect_weights = get_indirect_edges(vertices, faces)
+    edges = np.vstack([direct_edges, indirect_edges])
+    weights = np.concatenate([direct_weights, indirect_weights])
+
+    if mask is not None:
+        (excluded,) = np.where(mask)
+        keep = ~np.any(np.isin(edges, excluded), axis=1)
+        edges, weights = edges[keep], weights[keep]
+
+    return sparse.csr_matrix(
+        (weights, (edges[:, 0], edges[:, 1])),
+        shape=(len(vertices), len(vertices)),
+    )

--- a/src/neuromaps_prime/analysis/surfaces/points.py
+++ b/src/neuromaps_prime/analysis/surfaces/points.py
@@ -52,7 +52,7 @@ def _get_edges(faces: ArrayLike) -> np.ndarray:
     return np.sort(faces[:, [0, 1, 1, 2, 2, 0]].reshape((-1, 2)), axis=1)
 
 
-def get_directed_edges(
+def _get_directed_edges(
     vertices: ArrayLike, faces: ArrayLike
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute unique mesh edges and their Euclidean lengths.
@@ -82,7 +82,7 @@ def get_directed_edges(
     return edges, weights
 
 
-def get_indirect_edges(
+def _get_indirect_edges(
     vertices: ArrayLike, faces: ArrayLike
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute indirect edges and approximated geodesic distances.
@@ -116,7 +116,7 @@ def get_indirect_edges(
     """
     vertices = np.asarray(vertices)
     faces = np.asarray(faces)
-    triangles = np.stack(list(get_shared_triangles(faces).values()), axis=0)
+    triangles = np.stack(list(_get_shared_triangles(faces).values()), axis=0)
     indirect_edges = triangles[..., -1]
 
     v0, v1, opp = vertices[triangles].transpose(2, 3, 0, 1)
@@ -133,11 +133,8 @@ def get_indirect_edges(
     return indirect_edges, weights
 
 
-def point_in_triangle(
-    point: ArrayLike,
-    triangle: ArrayLike,
-    *,
-    return_pdist: bool = True,
+def _point_in_triangle(
+    point: ArrayLike, triangle: ArrayLike, *, return_pdist: bool = True
 ) -> tuple[bool, np.float64 | None]:
     """Test whether a 3-D point lies inside a triangular face.
 
@@ -200,14 +197,14 @@ def which_triangle(point: ArrayLike, triangles: ArrayLike) -> int | None:
     best = None
     best_dist = np.inf
     for i, tri in enumerate(triangles):
-        inside, pdist = point_in_triangle(point, tri)
+        inside, pdist = _point_in_triangle(point, tri)
         if inside and pdist is not None and pdist < best_dist:
             best = i
             best_dist = pdist
     return best
 
 
-def get_shared_triangles(faces: ArrayLike) -> dict[tuple[int, int], np.ndarray]:
+def _get_shared_triangles(faces: ArrayLike) -> dict[tuple[int, int], np.ndarray]:
     """Build a lookup from shared edges to adjacent triangle vertex triplets.
 
     In a watertight triangular mesh every internal edge belongs to exactly
@@ -276,9 +273,7 @@ def get_shared_triangles(faces: ArrayLike) -> dict[tuple[int, int], np.ndarray]:
 
 
 def make_surf_graph(
-    vertices: ArrayLike,
-    faces: ArrayLike,
-    mask: ArrayLike | None = None,
+    vertices: ArrayLike, faces: ArrayLike, mask: ArrayLike | None = None
 ) -> csr_matrix:
     """Build a sparse adjacency graph from a triangular surface mesh.
 
@@ -317,8 +312,8 @@ def make_surf_graph(
                 f"of vertices ({len(mask)} != {len(vertices)})"
             )
 
-    direct_edges, direct_weights = get_directed_edges(vertices, faces)
-    indirect_edges, indirect_weights = get_indirect_edges(vertices, faces)
+    direct_edges, direct_weights = _get_directed_edges(vertices, faces)
+    indirect_edges, indirect_weights = _get_indirect_edges(vertices, faces)
     edges = np.vstack([direct_edges, indirect_edges])
     weights = np.concatenate([direct_weights, indirect_weights])
 

--- a/src/neuromaps_prime/analysis/surfaces/points.py
+++ b/src/neuromaps_prime/analysis/surfaces/points.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy import sparse
+from scipy.sparse import csr_matrix
+from scipy.sparse.csgraph import dijkstra
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
@@ -278,7 +279,7 @@ def make_surf_graph(
     vertices: ArrayLike,
     faces: ArrayLike,
     mask: ArrayLike | None = None,
-) -> sparse.csr_matrix:
+) -> csr_matrix:
     """Build a sparse adjacency graph from a triangular surface mesh.
 
     Combines direct edges (shared between two vertices of a face) with
@@ -326,7 +327,53 @@ def make_surf_graph(
         keep = ~np.any(np.isin(edges, excluded), axis=1)
         edges, weights = edges[keep], weights[keep]
 
-    return sparse.csr_matrix(
+    return csr_matrix(
         (weights, (edges[:, 0], edges[:, 1])),
         shape=(len(vertices), len(vertices)),
     )
+
+
+def _geodesic_parcel_centroid(
+    vertices: ArrayLike, faces: ArrayLike, inds: ArrayLike
+) -> np.ndarray:
+    """Find the geodesic centroid vertex within a parcel.
+
+    Builds a surface mesh graph restricted to the parcel's vertices,
+    computes all-pairs shortest-path distances via Dijkstra, then
+    returns the vertex with the minimum mean distance to all other
+    vertices in the parcel.  This is the graph-theoretic *median* of
+    the parcel, analogous to a 1-median facility location problem.
+
+    The graph is constructed by masking out all vertices outside the
+    parcel, which removes edges touching those vertices and leaves only
+    the parcel's internal connectivity.
+
+    Args:
+        vertices: Array of shape ``(n_vertices, 3)`` containing the
+            3-D coordinates of every mesh vertex.
+        faces: Array of shape ``(n_faces, 3)`` where each row contains
+            vertex indices that define a triangular face.
+        inds: 1-D array of vertex indices belonging to the parcel.
+
+    Returns:
+        Array of shape ``(3,)`` with the 3-D coordinates of the centroid
+        vertex.
+
+    Raises:
+        ValueError: If *inds* is empty.
+    """
+    vertices = np.asarray(vertices)
+    faces = np.asarray(faces)
+    inds = np.asarray(inds)
+
+    if inds.size == 0:
+        raise ValueError("Parcel vertex indices (inds) are empty")
+
+    mask = np.ones(len(vertices), dtype=bool)
+    mask[inds] = False
+
+    mat = make_surf_graph(vertices, faces, mask)
+    dist_matrix = dijkstra(mat, directed=False, indices=inds)[:, inds]
+    centroid_idx = int(dist_matrix.mean(axis=1).argmin())
+
+    return vertices[inds[centroid_idx]]

--- a/src/neuromaps_prime/analysis/surfaces/points.py
+++ b/src/neuromaps_prime/analysis/surfaces/points.py
@@ -15,14 +15,34 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import nibabel as nib
 import numpy as np
+from joblib import Parallel, delayed
+from scipy import ndimage
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import dijkstra
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
     from numpy.typing import ArrayLike
 
-__all__ = ["make_surf_graph"]
+__all__ = ["get_surface_distance", "make_surf_graph"]
+
+# Default parcellations to ignore
+_PARC_IGNORE = frozenset(
+    {
+        "unknown",
+        "corpuscallosum",
+        "Background+FreeSurfer_Defined_Medial_Wall",
+        "???",
+        "Unknown",
+        "Medial_wall",
+        "Medial wall",
+        "medial_wall",
+    }
+)
 
 
 def _get_edges(faces: ArrayLike) -> np.ndarray:
@@ -78,7 +98,7 @@ def _get_directed_edges(
     faces = np.asarray(faces)
     vertices = np.asarray(vertices)
     edges = np.unique(_get_edges(faces), axis=0)
-    weights = np.linalg.norm(np.diff(vertices[edges], axis=1), axis=-1)
+    weights = np.linalg.norm(np.diff(vertices[edges], axis=1), axis=-1).squeeze()
     return edges, weights
 
 
@@ -372,3 +392,188 @@ def _geodesic_parcel_centroid(
     centroid_idx = int(dist_matrix.mean(axis=1).argmin())
 
     return vertices[inds[centroid_idx]]
+
+
+def _load_gifti(surface: str | Path) -> nib.GiftiImage:
+    """Load a GIFTI surface or label file.
+
+    Args:
+        surface: Path to a GIFTI file (``.gii``, ``.func.gii``, etc.).
+
+    Returns:
+        A ``nibabel.GiftiImage`` instance.
+
+    Raises:
+        ValueError: If the loaded image is not a GiftiImage.
+    """
+    img = nib.load(surface)
+    if not isinstance(img, nib.GiftiImage):
+        raise ValueError(f"Expected to load Gifti surface for: {surface}")
+    return img
+
+
+def _relabel_gifti(
+    parcellation: str | Path,
+    background: Iterable[str] | None = None,
+) -> nib.GiftiImage:
+    """Relabel a GIFTI parcellation so that label indices are consecutive.
+
+    Loads the parcellation file, zeroes out any background labels found in
+    the label table, then remaps the remaining indices to consecutive
+    integers starting at ``1``.  Returns a new ``GiftiImage`` with an
+    updated data array and label table.
+
+    Args:
+        parcellation: Path to a single GIFTI parcellation file.
+        background: Iterable of label names to treat as background and
+            zero out. Defaults to ``_PARC_IGNORE``.
+
+    Returns:
+        A ``GiftiImage`` instance with consecutive label indices and an
+        updated label table.
+    """
+    img = _load_gifti(parcellation)
+    data = img.agg_data().copy()
+    labels = img.labeltable.labels
+    lut = {v: k for k, v in img.labeltable.get_labels_as_dict().items()}
+
+    if background is None:
+        background = _PARC_IGNORE
+
+    # Zero out background labels
+    if len(labels) > 0:
+        for val in background:
+            idx = lut.get(val)
+            if idx is None:
+                continue
+            data[data == idx] = 0
+            labels = [f for f in labels if f.key != idx]
+
+    # Remap to consecutive indices starting at 1
+    data = np.unique(data, return_inverse=True)[-1]
+    new_labels = []
+    if len(labels) > 0:
+        for n, lab in enumerate(labels, start=1):
+            lab.key = n
+            new_labels.append(lab)
+
+    # Build updated GIFTI image
+    darr = nib.gifti.GiftiDataArray(
+        data, intent="NIFTI_INTENT_LABEL", datatype="NIFTI_TYPE_INT32"
+    )
+    labeltable = nib.gifti.GiftiLabelTable()
+    labeltable.labels = new_labels
+    return nib.GiftiImage(darrays=[darr], labeltable=labeltable)
+
+
+def _get_graph_distance(
+    vertex: int,
+    graph: csr_matrix,
+    labels: np.ndarray | None = None,
+    unique_labels: np.ndarray | None = None,
+) -> np.ndarray:
+    """Compute shortest-path distances from a single vertex.
+
+    Runs single-source Dijkstra on the mesh adjacency graph.  If parcel
+    labels are provided, distances are aggregated to the parcel level by
+    computing the mean distance within each parcel (excluding the source
+    vertex).
+
+    Args:
+        vertex: Source vertex index.
+        graph: Sparse adjacency matrix of shape ``(n_vertices, n_vertices)``.
+        labels: Optional 1-D array of parcel labels (length ``n_vertices``).
+        unique_labels: Sorted unique parcel labels. Precomputed to avoid
+            redundant work inside the parallel worker. Must be provided
+            alongside *labels*, or both must be ``None``.
+
+    Returns:
+        1-D array of distances.  If *labels* is ``None``, shape is
+        ``(n_vertices,)``.  If provided, shape is ``(n_parcels,)``.
+
+    Raises:
+        ValueError: If one of *labels* or *unique_labels* is ``None``
+            and the other is not.
+    """
+    dist = dijkstra(graph, directed=False, indices=[vertex]).squeeze()
+    if not (labels is None) == (unique_labels is None):
+        raise ValueError(
+            "Both 'labels' and 'unique_labels' must both be provided or None"
+        )
+    if labels is not None:
+        dist = ndimage.mean(
+            input=np.delete(dist, vertex),
+            labels=np.delete(labels, vertex),
+            index=unique_labels,
+        )
+    return dist.astype("float32")
+
+
+def get_surface_distance(
+    surface: str | Path,
+    *,
+    parcellation: str | Path | None = None,
+    medial: str | Path | None = None,
+    medial_labels: Iterable[str] | None = None,
+    drop: Iterable[str] = _PARC_IGNORE,
+    n_proc: int = 1,
+) -> np.ndarray:
+    """Compute a geodesic distance matrix on a cortical surface.
+
+    Loads a surface, builds a mesh adjacency graph, then runs
+    single-source Dijkstra from every vertex.  If a parcellation is
+    provided, vertex-level distances are aggregated to the parcel level
+    by averaging within each parcel.  Medial-wall vertices and
+    background parcels are excluded from the graph before computation.
+
+    Args:
+        surface: Path to a GIFTI sphere surface file.
+        parcellation: Path to a GIFTI parcellation file. If provided,
+            vertex-level distances are averaged within each parcel to
+            produce a parcel-to-parcel distance matrix.
+        medial: Path to a GIFTI medial-wall mask file. If provided,
+            vertices marked as medial wall are excluded from the graph.
+        medial_labels: Iterable of label names to intersect with *drop*
+            to narrow which labels are excluded. When provided, only
+            labels present in both *drop* and *medial_labels* are
+            dropped.
+        drop: Iterable of label names to exclude from the graph.
+            Defaults to ``_PARC_IGNORE``.
+        n_proc: Number of parallel workers for Dijkstra computation.
+
+    Returns:
+        A distance matrix.  If *parcellation* is provided, returns a
+        parcel-to-parcel matrix of shape ``(n_parcels - 1,``
+        ``n_parcels - 1)`` (background parcel stripped).  Otherwise
+        returns a vertex-to-vertex matrix of shape
+        ``(n_vertices, n_vertices)``.
+    """
+    if medial_labels is not None:
+        drop = set(drop) & set(medial_labels)
+
+    vert, faces = _load_gifti(surface).agg_data()
+    n_vert = vert.shape[0]
+    labels, mask = None, np.zeros(n_vert, dtype=bool)
+
+    if medial is not None:
+        mask = _load_gifti(medial).agg_data().astype(bool)
+    if parcellation is not None:
+        parcellation_img = _relabel_gifti(parcellation, background=drop)
+        labels = parcellation_img.agg_data()
+        mask[labels == 0] = True
+
+    graph = make_surf_graph(vert, faces, mask=mask)
+    unique_labels = np.unique(labels) if labels is not None else None
+    dist = np.vstack(
+        Parallel(n_jobs=n_proc, max_bytes=None)(
+            delayed(_get_graph_distance)(n, graph, labels, unique_labels)
+            for n in range(n_vert)
+        )
+    )
+
+    if labels is not None and unique_labels is not None:
+        dist = np.vstack([dist[labels == lab].mean(axis=0) for lab in unique_labels])
+        dist[np.diag_indices_from(dist)] = 0
+        dist = dist[1:, 1:]
+
+    return dist

--- a/src/neuromaps_prime/analysis/surfaces/points.py
+++ b/src/neuromaps_prime/analysis/surfaces/points.py
@@ -1,0 +1,271 @@
+"""Surface mesh geometry operations.
+
+Provides tools for building mesh adjacency graphs, computing geodesic
+distances between vertices or parcels, and finding parcel centroids on
+cortical surfaces.  Unlike the graph module, which models brain spaces as
+abstract nodes and edges, this module works directly with triangular mesh
+topology to support spatial operations that have no CTF or workbench
+equivalent (e.g., Dijkstra-based shortest-path distance on a surface).
+
+Adapted from the neuromaps codebase
+(https://github.com/netneurolab/neuromaps/blob/main/neuromaps/points.py).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+
+def _get_edges(faces: ArrayLike) -> np.ndarray:
+    """Extract all unique edge pairs from a triangular mesh face array.
+
+    Each triangular face contributes three edges: ``(v0, v1)``,
+    ``(v1, v2)``, and ``(v2, v0)``.  Vertex indices within each edge
+    are sorted so that the representation is canonical (direction-
+    independent), making it straightforward to deduplicate with
+    ``np.unique``.
+
+    Args:
+        faces: Array of shape ``(n_faces, 3)`` where each row contains
+            vertex indices that define a triangular face of the mesh.
+
+    Returns:
+        Array of shape ``(n_faces * 3, 2)`` containing all directed edge
+        pairs, sorted within each row so that the smaller vertex index
+        appears first.
+
+    Note:
+        This function returns *all* edges, including duplicates from
+        adjacent triangles that share an edge.  Deduplication is left to
+        downstream callers.
+    """
+    faces = np.asarray(faces)
+    return np.sort(faces[:, [0, 1, 1, 2, 2, 0]].reshape((-1, 2)), axis=1)
+
+
+def get_directed_edges(
+    vertices: ArrayLike, faces: ArrayLike
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute unique mesh edges and their Euclidean lengths.
+
+    Extracts all edges from the triangular faces, deduplicates them,
+    then computes the straight-line distance between the two vertices
+    of each edge.
+
+    Args:
+        vertices: Array of shape ``(n_vertices, 3)`` containing the
+            3-D coordinates of every mesh vertex.
+        faces: Array of shape ``(n_faces, 3)`` where each row contains
+            vertex indices that define a triangular face.
+
+    Returns:
+        A tuple ``(edges, weights)`` where:
+
+            edges:  Array of shape ``(n_edges, 2)`` with unique,
+                sorted vertex-index pairs.
+            weights: 1-D array of shape ``(n_edges,)`` containing the
+                Euclidean length of each edge.
+    """
+    faces = np.asarray(faces)
+    vertices = np.asarray(vertices)
+    edges = np.unique(_get_edges(faces), axis=0)
+    weights = np.linalg.norm(np.diff(vertices[edges], axis=1), axis=-1)
+    return edges, weights
+
+
+def get_indirect_edges(
+    vertices: ArrayLike, faces: ArrayLike
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute indirect edges and approximated geodesic distances.
+
+    Indirect edges connect pairs of opposite vertices from triangles
+    that share a common edge.  The weight approximates the geodesic
+    distance: each opposite vertex is orthogonally projected onto the
+    shared edge, the midpoint between the two projection points is
+    computed, and the sum of distances from each opposite vertex to
+    that midpoint forms the edge weight.
+
+    Args:
+        vertices: Array of shape ``(n_vertices, 3)`` containing the
+            3-D coordinates of every mesh vertex.
+        faces: Array of shape ``(n_faces, 3)`` where each row contains
+            vertex indices that define a triangular face.
+
+    Returns:
+        A tuple ``(edges, weights)`` where:
+
+            edges: Array of shape ``(n_pairs, 2)`` with vertex-index
+                pairs of opposite vertices from adjacent triangles.
+            weights: 1-D array of shape ``(n_pairs,)`` containing the
+                approximated geodesic distance between each pair.
+
+    Note:
+        The projection can fall outside the shared edge when either
+        triangle has an obtuse angle along that edge, introducing
+        small errors. Adapted from trimesh
+        (https://github.com/mikedh/trimesh).
+    """
+    vertices = np.asarray(vertices)
+    faces = np.asarray(faces)
+    triangles = np.stack(list(get_shared_triangles(faces).values()), axis=0)
+    indirect_edges = triangles[..., -1]
+
+    v0, v1, opp = vertices[triangles].transpose(2, 3, 0, 1)
+
+    edge_vec = v0 - v1
+    proj = np.sum(edge_vec * (opp - v1), axis=0, keepdims=True) / np.sum(
+        edge_vec**2, axis=0, keepdims=True
+    )
+    feet = v1 + proj * edge_vec
+    midpoints = np.sum(feet.transpose(1, 2, 0), axis=1) / 2
+    norms = np.linalg.norm(vertices[indirect_edges] - midpoints[:, None], axis=-1)
+    weights = np.sum(norms, axis=-1)
+
+    return indirect_edges, weights
+
+
+def point_in_triangle(
+    point: ArrayLike,
+    triangle: ArrayLike,
+    *,
+    return_pdist: bool = True,
+) -> tuple[bool, np.float64 | None]:
+    """Test whether a 3-D point lies inside a triangular face.
+
+    Uses barycentric coordinates: expresses the point relative to vertex
+    ``A`` as ``P = A + u*v0 + v*v1`` and checks ``u >= 0``, ``v >= 0``,
+    and ``u + v < 1``.  See
+    https://blackpawn.com/texts/pointinpoly/ for a full derivation.
+
+    Args:
+        point: Array of shape ``(3,)`` with the 3-D coordinates to test.
+        triangle: Array of shape ``(3, 3)`` with the 3-D coordinates of
+            the three vertices defining a triangular face.
+        return_pdist: Whether to also return the perpendicular distance
+            from the point to the plane of the triangle. Default ``True``.
+
+    Returns:
+        A tuple ``(inside, pdist)`` where:
+
+            inside: Whether the point lies inside the triangle.
+            pdist: The volume of the parallelepiped spanned by the two
+                triangle edge vectors and the vector from a vertex to
+                the point. ``None`` when *return_pdist* is ``False``.
+    """
+    point = np.asarray(point)
+    triangle = np.asarray(triangle)
+    a, b, c = triangle
+    v0, v1, v2 = c - a, b - a, point - a
+
+    d00 = v0 @ v0
+    d01 = v0 @ v1
+    d11 = v1 @ v1
+    d02 = v0 @ v2
+    d12 = v1 @ v2
+    inv_denom = 1.0 / (d00 * d11 - d01 * d01)
+    u = (d11 * d02 - d01 * d12) * inv_denom
+    v = (d00 * d12 - d01 * d02) * inv_denom
+    inside = u >= 0 and v >= 0 and u + v < 1
+
+    if return_pdist:
+        return inside, np.abs(v2 @ np.cross(v1, v0))
+    return inside, None
+
+
+def which_triangle(point: ArrayLike, triangles: ArrayLike) -> int | None:
+    """Find the triangle that best contains a 3-D point.
+
+    Iterates over candidate triangles, keeping the one with the smallest
+    planar distance to *point* among those that contain it.
+
+    Args:
+        point: Array of shape ``(3,)`` with the 3-D coordinates to test.
+        triangles: Array of shape ``(n_triangles, 3, 3)`` where each
+            inner ``(3, 3)`` block is a set of three vertex coordinates.
+
+    Returns:
+        The index of the best-matching triangle, or ``None`` if no
+        triangle contains the point.
+    """
+    triangles = np.asarray(triangles)
+    best = None
+    best_dist = np.inf
+    for i, tri in enumerate(triangles):
+        inside, pdist = point_in_triangle(point, tri)
+        if inside and pdist is not None and pdist < best_dist:
+            best = i
+            best_dist = pdist
+    return best
+
+
+def get_shared_triangles(faces: ArrayLike) -> dict[tuple[int, int], np.ndarray]:
+    """Build a lookup from shared edges to adjacent triangle vertex triplets.
+
+    In a watertight triangular mesh every internal edge belongs to exactly
+    two triangles.  This function finds all such shared edges and maps each
+    to the vertex triplets of its two adjacent triangles.
+
+    Algorithm:
+        1. Extract every edge from the face array (3 edges per face, vertex
+           indices sorted so each edge is canonical).
+        2. Lexicographic sort groups duplicate edges together.
+        3. Keep only groups of size 2 — edges shared by exactly two
+           different triangles (boundary edges are excluded).
+        4. For each shared edge, identify the vertex in each adjacent
+           triangle that is NOT part of the edge (the "opposite" vertex).
+        5. Return a dict mapping each shared edge to an array of shape
+           ``(2, 3)`` containing the two vertex triplets.
+
+    Args:
+        faces: Array of shape ``(n_faces, 3)`` where each row contains
+            vertex indices that define a triangular face.
+
+    Returns:
+        Dictionary where keys are 2-tuples ``(v0, v1)`` representing a
+        shared edge (with ``v0 < v1``), and values are arrays of shape
+        ``(2, 3)``. Each row of a value is a vertex triplet
+        ``(v0, v1, opposite_vertex)`` where ``opposite_vertex`` is the
+        third vertex in that triangle.
+
+    Note:
+        Boundary edges (belonging to only one triangle) are excluded.
+        This function assumes a manifold mesh.
+    """
+    faces = np.asarray(faces)
+    edges = _get_edges(faces)
+    edge_face = np.repeat(np.arange(len(faces)), 3)
+
+    order = np.lexsort(edges.T[::-1])
+    sorted_edges = edges[order]
+
+    group_boundary = np.any(sorted_edges[1:] != sorted_edges[:-1], axis=1)
+    group_starts = np.concatenate([[0], np.where(group_boundary)[0] + 1])
+    group_lengths = np.diff(np.concatenate([group_starts, [len(sorted_edges)]]))
+    starts = group_starts[group_lengths == 2]
+
+    pair_idx = order[starts[:, None] + np.arange(2)]
+    face_pairs = edge_face[pair_idx]
+
+    valid = face_pairs[:, 0] != face_pairs[:, 1]
+    face_pairs = face_pairs[valid]
+    pair_idx = pair_idx[valid]
+    shared_edges = edges[pair_idx[:, 0]]
+
+    n = len(face_pairs)
+    opposite = np.empty((n, 2), dtype=faces.dtype)
+    for col in range(2):
+        tri = faces[face_pairs[:, col]]
+        in_edge = (tri == shared_edges[:, 0:1]) | (tri == shared_edges[:, 1:2])
+        opp_pos = (~in_edge).argmax(axis=1)
+        opposite[:, col] = tri[np.arange(n), opp_pos]
+
+    triplets = np.empty((n, 2, 3), dtype=faces.dtype)
+    triplets[:, :, :2] = shared_edges
+    triplets[:, :, 2] = opposite
+
+    return dict(zip(map(tuple, shared_edges), triplets, strict=True))

--- a/tests/unit/analysis/test_points.py
+++ b/tests/unit/analysis/test_points.py
@@ -1,0 +1,332 @@
+"""Tests for surface mesh geometry operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import nibabel as nib
+import numpy as np
+import pytest
+
+from neuromaps_prime.analysis.surfaces import points
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from scipy.sparse import csr_matrix
+
+
+# Simple triangle in the XY plane.
+simple_vertices = np.array(
+    [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+    dtype=np.float32,
+)
+simple_faces = np.array([[0, 1, 2]], dtype=np.int32)
+
+# Unit square split into two triangles sharing edge (1, 2).
+square_vertices = np.array(
+    [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0]],
+    dtype=np.float32,
+)
+square_faces = np.array([[0, 1, 2], [1, 3, 2]], dtype=np.int32)
+
+
+def _make_gifti_surface(coords: np.ndarray, faces: np.ndarray, path: Path) -> None:
+    """Write a GIFTI surface file."""
+    ptarr = nib.gifti.GiftiDataArray(
+        coords.astype(np.float32), intent="NIFTI_INTENT_POINTSET"
+    )
+    tris = nib.gifti.GiftiDataArray(faces, intent="NIFTI_INTENT_TRIANGLE")
+    nib.GiftiImage(darrays=[ptarr, tris]).to_filename(path)
+
+
+def _make_gifti_parc(
+    data: np.ndarray,
+    labels: list[tuple[int, str]],
+    path: Path,
+) -> None:
+    """Write a GIFTI parcellation file."""
+    darr = nib.gifti.GiftiDataArray(
+        data.astype(np.int32), intent="NIFTI_INTENT_LABEL", datatype="NIFTI_TYPE_INT32"
+    )
+    lt = nib.gifti.GiftiLabelTable()
+    for key, name in labels:
+        lbl = nib.gifti.GiftiLabel(key=key)
+        lbl.label = name
+        lt.labels.append(lbl)
+    nib.GiftiImage(darrays=[darr], labeltable=lt).to_filename(path)
+
+
+@pytest.fixture(scope="module")
+def surf_gifti_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """GIFTI surface file for the simple triangle."""
+    p = tmp_path_factory.mktemp("data") / "sphere.surf.gii"
+    _make_gifti_surface(coords=simple_vertices, faces=simple_faces, path=p)
+    return p
+
+
+@pytest.fixture(scope="module")
+def square_surf_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """GIFTI surface file for the square mesh."""
+    p = tmp_path_factory.mktemp("data") / "square.surf.gii"
+    _make_gifti_surface(coords=square_vertices, faces=square_faces, path=p)
+    return p
+
+
+@pytest.fixture(scope="module")
+def parc_gifti_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """GIFTI parcellation file."""
+    p = tmp_path_factory.mktemp("data") / "parc.label.gii"
+    _make_gifti_parc(
+        data=np.array([1, 1, 2], dtype=np.int32), labels=[(1, "A"), (2, "B")], path=p
+    )
+    return p
+
+
+@pytest.fixture(scope="module")
+def square_graph() -> csr_matrix:
+    """Adjacency graph for the square mesh."""
+    return points.make_surf_graph(vertices=square_vertices, faces=square_faces)
+
+
+class TestGetEdges:
+    """Tests for _get_edges()."""
+
+    def test_shape_and_sorted(self) -> None:
+        """Verify output shape and canonical edge ordering."""
+        edges = points._get_edges(simple_faces)
+        assert edges.shape == (3, 2)
+        assert np.all(edges[:, 0] <= edges[:, 1])
+        edge_set = set(map(tuple, edges))
+        assert (0, 1) in edge_set
+        assert (1, 2) in edge_set
+        assert (0, 2) in edge_set
+
+
+class TestGetDirectedEdges:
+    """Tests for _get_directed_edges()."""
+
+    def test_deduplication(self) -> None:
+        """Verify square mesh produces deduplicated edges."""
+        edges, _ = points._get_directed_edges(
+            vertices=square_vertices, faces=square_faces
+        )
+        assert edges.shape[0] == 5
+
+    def test_weights(self) -> None:
+        """Verify weights are 1-D with expected Euclidean lengths."""
+        _, weights = points._get_directed_edges(
+            vertices=square_vertices, faces=square_faces
+        )
+        assert weights.ndim == 1
+        assert sum(np.isclose(weights, 1.0)) == 4
+        diag = weights[~np.isclose(weights, 1.0)]
+        assert np.isclose(diag[0], np.sqrt(2))
+
+
+class TestGetIndirectEdges:
+    """Tests for _get_indirect_edges()."""
+
+    def test_shared_edge(self) -> None:
+        """Verify indirect edge exists between opposite vertices of shared edge."""
+        edges, weights = points._get_indirect_edges(
+            vertices=square_vertices, faces=square_faces
+        )
+        edge_set = set(map(frozenset, edges))
+        assert frozenset({0, 3}) in edge_set
+        assert np.all(weights > 0)
+
+
+class TestPointInTriangle:
+    """Tests for _point_in_triangle()."""
+
+    def test_centroid_inside(self) -> None:
+        """Verify centroid is inside and pdist is non-negative."""
+        centroid = simple_vertices.mean(axis=0)
+        inside, pdist = points._point_in_triangle(
+            point=centroid, triangle=simple_vertices
+        )
+        assert inside
+        assert pdist is not None
+        assert pdist >= 0
+
+    def test_outside(self) -> None:
+        """Verify a point outside the triangle is rejected."""
+        inside, _ = points._point_in_triangle(
+            point=np.array([10.0, 10.0, 0.0]), triangle=simple_vertices
+        )
+        assert not inside
+
+    def test_no_pdist(self) -> None:
+        """Verify pdist is None when disabled."""
+        _, pdist = points._point_in_triangle(
+            point=simple_vertices.mean(axis=0),
+            triangle=simple_vertices,
+            return_pdist=False,
+        )
+        assert pdist is None
+
+
+class TestWhichTriangle:
+    """Tests for which_triangle()."""
+
+    def test_found(self) -> None:
+        """Verify the centroid is found inside triangle 0."""
+        assert (
+            points.which_triangle(
+                point=simple_vertices.mean(axis=0),
+                triangles=simple_vertices[simple_faces],
+            )
+            == 0
+        )
+
+    def test_not_found(self) -> None:
+        """Verify a far-away point returns None."""
+        assert (
+            points.which_triangle(
+                point=np.array([100.0, 100.0, 100.0]),
+                triangles=simple_vertices[simple_faces],
+            )
+            is None
+        )
+
+
+class TestMakeSurfGraph:
+    """Tests for make_surf_graph()."""
+
+    def test_shape_and_weights(self, square_graph: csr_matrix) -> None:
+        """Verify graph shape, no self-loops, and positive weights."""
+        assert square_graph.shape == (4, 4)
+        assert np.all(square_graph.diagonal() == 0)
+        assert np.all(square_graph.data > 0)
+
+    def test_mask_excludes(self) -> None:
+        """Verify mask removes edges touching excluded vertices."""
+        g = points.make_surf_graph(
+            vertices=square_vertices,
+            faces=square_faces,
+            mask=np.array([False, False, True, False]),
+        )
+        assert g[2, :].nnz == 0
+        assert g[:, 2].nnz == 0
+
+    def test_bad_mask_raises(self) -> None:
+        """Verify mismatched mask size raises ValueError."""
+        with pytest.raises(ValueError, match="different number"):
+            points.make_surf_graph(
+                vertices=square_vertices,
+                faces=square_faces,
+                mask=np.array([True, False]),
+            )
+
+
+class TestGeodesicParcelCentroid:
+    """Tests for _geodesic_parcel_centroid()."""
+
+    def test_returns_vertex(self) -> None:
+        """Verify the centroid is one of the parcel's vertices."""
+        centroid = points._geodesic_parcel_centroid(
+            vertices=square_vertices, faces=square_faces, inds=np.array([0, 1])
+        )
+        assert tuple(centroid) in (tuple(square_vertices[0]), tuple(square_vertices[1]))
+
+    def test_empty_raises(self) -> None:
+        """Verify empty parcel index list raises ValueError."""
+        with pytest.raises(ValueError, match="empty"):
+            points._geodesic_parcel_centroid(
+                vertices=square_vertices,
+                faces=square_faces,
+                inds=np.array([], dtype=int),
+            )
+
+
+class TestLoadGifti:
+    """Tests for _load_gifti()."""
+
+    def test_returns_gifti(self, surf_gifti_path: Path) -> None:
+        """Verify loading a valid GIFTI file returns a GiftiImage."""
+        assert isinstance(points._load_gifti(surf_gifti_path), nib.GiftiImage)
+
+    def test_wrong_type_raises(self, tmp_path: Path) -> None:
+        """Verify loading a non-GIFTI file raises ValueError."""
+        nii_path = tmp_path / "dummy.nii.gz"
+        nib.Nifti1Image(np.zeros((2, 2, 2)), np.eye(4)).to_filename(str(nii_path))
+        with pytest.raises(ValueError, match="Gifti"):
+            points._load_gifti(nii_path)
+
+
+class TestRelabelGifti:
+    """Tests for _relabel_gifti()."""
+
+    def test_consecutive(self, parc_gifti_path: Path) -> None:
+        """Verify output labels are remapped to consecutive indices."""
+        unique = np.unique(points._relabel_gifti(parc_gifti_path).agg_data())
+        np.testing.assert_array_equal(unique, [0, 1])
+
+    def test_background_zeroed(self, tmp_path_factory: pytest.TempPathFactory) -> None:
+        """Verify background labels are zeroed out."""
+        p = tmp_path_factory.mktemp("data") / "parc_bg.label.gii"
+        _make_gifti_parc(
+            data=np.array([1, 2, 3], dtype=np.int32),
+            labels=[(1, "Cortex"), (2, "unknown"), (3, "Stem")],
+            path=p,
+        )
+        data = points._relabel_gifti(p).agg_data()
+        assert data[1] == 0
+        np.testing.assert_array_equal(np.unique(data[data > 0]), [1, 2])
+
+
+class TestGetGraphDistance:
+    """Tests for _get_graph_distance()."""
+
+    def test_dtype_and_self(self, square_graph: csr_matrix) -> None:
+        """Verify output dtype is float32 and distance to self is zero."""
+        dist = points._get_graph_distance(0, square_graph)
+        assert dist.dtype == np.float32
+        assert dist[0] == 0.0
+        assert np.all(dist[1:] > 0)
+
+    def test_parcel_aggregation(self, square_graph: csr_matrix) -> None:
+        """Verify parcel-level aggregation returns correct shape."""
+        labels = np.array([1, 1, 2, 2], dtype=int)
+        dist = points._get_graph_distance(
+            0, square_graph, labels=labels, unique_labels=np.array([1, 2], dtype=int)
+        )
+        assert dist.shape == (2,)
+
+    def test_arg_mismatch_raises(self, square_graph: csr_matrix) -> None:
+        """Verify mismatched labels/unique_labels raises ValueError."""
+        labels = np.array([1, 1, 2, 2], dtype=int)
+        for args in (
+            {"labels": labels, "unique_labels": None},
+            {"labels": None, "unique_labels": np.array([1, 2])},
+        ):
+            with pytest.raises(ValueError, match="both"):
+                points._get_graph_distance(0, square_graph, **args)
+
+
+class TestGetSurfaceDistance:
+    """Tests for get_surface_distance()."""
+
+    def test_vertex_level(self, square_surf_path: str) -> None:
+        """Verify vertex-level distance matrix shape and zero diagonal."""
+        dist = points.get_surface_distance(square_surf_path, n_proc=1)
+        assert dist.shape == (4, 4)
+        np.testing.assert_allclose(np.diag(dist), 0)
+
+    def test_parcel_level(
+        self, square_surf_path: str, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        """Verify parcel-to-parcel distance matrix shape."""
+        parc_path = tmp_path_factory.mktemp("data") / "parc.label.gii"
+        _make_gifti_parc(
+            np.array([1, 1, 2, 3], dtype=np.int32),
+            [(1, "A"), (2, "B"), (3, "C")],
+            parc_path,
+        )
+        dist = points.get_surface_distance(
+            square_surf_path, parcellation=parc_path, n_proc=1
+        )
+        # 3 parcels (incl. background) -> strip row/col 0 -> (2, 2)
+        assert dist.shape == (2, 2)
+        np.testing.assert_allclose(np.diag(dist), 0)

--- a/uv.lock
+++ b/uv.lock
@@ -531,6 +531,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -975,6 +984,7 @@ wheels = [
 name = "neuromaps-prime"
 source = { editable = "." }
 dependencies = [
+    { name = "joblib" },
     { name = "matplotlib" },
     { name = "networkx" },
     { name = "nibabel" },
@@ -1014,6 +1024,7 @@ validate = [
 
 [package.metadata]
 requires-dist = [
+    { name = "joblib", specifier = ">=1.5.3" },
     { name = "matplotlib", specifier = ">=3.10.7" },
     { name = "networkx", specifier = ">=3.6.1" },
     { name = "nibabel", specifier = ">=5.2.1" },


### PR DESCRIPTION
## This PR:
Introduces a new `analysis.surfaces.points` module for surface mesh geometry operations (lifted from neuromaps), including:
  - sparse mesh adjacency graph construction -
  - Dijkstra-based geodesic distance computation on cortical surfaces 
  - parcel centroid finding. 
 
These functions operate directly on GIFTI surface topology to support surface-aware spatial analysis.

## Type of Change
- [ ] Bug fix
- [x] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)
- #193 by @kaitj 