### PR TITLE
chore: bump niwrap patch to >=0.9.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only"
 ]
 dependencies = [
-  "niwrap>=0.9.2,<1.0",
+  "niwrap>=0.9.6,<1.0",
   "nibabel>=5.2.1",
   "pyyaml>=6.0.2",
   "networkx>=3.6.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1028,7 +1028,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.10.7" },
     { name = "networkx", specifier = ">=3.6.1" },
     { name = "nibabel", specifier = ">=5.2.1" },
-    { name = "niwrap", specifier = ">=0.9.2,<1.0" },
+    { name = "niwrap", specifier = ">=0.9.6,<1.0" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "platformdirs", specifier = ">=4.10.0" },
     { name = "pydantic", specifier = ">=2.12.3" },


### PR DESCRIPTION
## This PR:
Fixes some bugs that are present with `niwrap>=0.9.3, <0.9.6`

## Type of Change
- [x] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)
- n/a