### PR TITLE
feat: add spatial null model modules

### DIFF
--- a/src/neuromaps_prime/analysis/images.py
+++ b/src/neuromaps_prime/analysis/images.py
@@ -12,7 +12,19 @@ from pathlib import Path
 import nibabel as nib
 import numpy as np
 
-from neuromaps_prime.analysis.surfaces.points import PARC_IGNORE
+# Default parcellation labels to ignore (unknown regions, medial wall, etc.)
+PARC_IGNORE = frozenset(
+    {
+        "unknown",
+        "corpuscallosum",
+        "Background+FreeSurfer_Defined_Medial_Wall",
+        "???",
+        "Unknown",
+        "Medial_wall",
+        "Medial wall",
+        "medial_wall",
+    }
+)
 
 
 def load_gifti(surface: str | Path) -> nib.GiftiImage:

--- a/src/neuromaps_prime/analysis/images.py
+++ b/src/neuromaps_prime/analysis/images.py
@@ -1,0 +1,87 @@
+"""Image loading and label manipulation utilities.
+
+Provides functions to load image data (e.g. surface) and
+parcellation files and to relabel parcellation data so
+that label indices are consecutive, with background regions
+zeroed out.
+"""
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+
+from neuromaps_prime.analysis.surfaces.points import PARC_IGNORE
+
+
+def load_gifti(surface: str | Path) -> nib.GiftiImage:
+    """Load a GIFTI surface or label file.
+
+    Args:
+        surface: Path to a GIFTI file (``.gii``, ``.func.gii``, etc.).
+
+    Returns:
+        A ``nibabel.GiftiImage`` instance.
+
+    Raises:
+        ValueError: If the loaded image is not a GiftiImage.
+    """
+    img = nib.load(surface)
+    if not isinstance(img, nib.GiftiImage):
+        raise ValueError(f"Expected to load Gifti surface for: {surface}")
+    return img
+
+
+def relabel_gifti(
+    parcellation: str | Path,
+    background: Iterable[str] | None = None,
+) -> nib.GiftiImage:
+    """Relabel a GIFTI parcellation so that label indices are consecutive.
+
+    Loads the parcellation file, zeroes out any background labels found in
+    the label table, then remaps the remaining indices to consecutive
+    integers starting at ``1``.  Returns a new ``GiftiImage`` with an
+    updated data array and label table.
+
+    Args:
+        parcellation: Path to a single GIFTI parcellation file.
+        background: Iterable of label names to treat as background and
+            zero out. Defaults to ``PARC_IGNORE``.
+
+    Returns:
+        A ``GiftiImage`` instance with consecutive label indices and an
+        updated label table.
+    """
+    img = load_gifti(parcellation)
+    data = img.agg_data().copy()
+    labels = img.labeltable.labels
+    lut = {v: k for k, v in img.labeltable.get_labels_as_dict().items()}
+
+    if background is None:
+        background = PARC_IGNORE
+
+    # Zero out background labels
+    if len(labels) > 0:
+        for val in background:
+            idx = lut.get(val)
+            if idx is None:
+                continue
+            data[data == idx] = 0
+            labels = [f for f in labels if f.key != idx]
+
+    # Remap to consecutive indices starting at 1
+    data = np.unique(data, return_inverse=True)[-1]
+    new_labels = []
+    if len(labels) > 0:
+        for n, lab in enumerate(labels, start=1):
+            lab.key = n
+            new_labels.append(lab)
+
+    # Build updated GIFTI image
+    darr = nib.gifti.GiftiDataArray(
+        data, intent="NIFTI_INTENT_LABEL", datatype="NIFTI_TYPE_INT32"
+    )
+    labeltable = nib.gifti.GiftiLabelTable()
+    labeltable.labels = new_labels
+    return nib.GiftiImage(darrays=[darr], labeltable=labeltable)

--- a/src/neuromaps_prime/analysis/surfaces/__init__.py
+++ b/src/neuromaps_prime/analysis/surfaces/__init__.py
@@ -7,10 +7,9 @@ space-agnostic statistics in :mod:`neuromaps_prime.analysis.stats` with
 operations that require surface topology.
 """
 
-from neuromaps_prime.analysis.surfaces import nulls
 from neuromaps_prime.analysis.surfaces.points import (
     get_surface_distance,
     make_surf_graph,
 )
 
-__all__ = ["get_surface_distance", "make_surf_graph", "nulls"]
+__all__ = ["get_surface_distance", "make_surf_graph"]

--- a/src/neuromaps_prime/analysis/surfaces/__init__.py
+++ b/src/neuromaps_prime/analysis/surfaces/__init__.py
@@ -7,9 +7,10 @@ space-agnostic statistics in :mod:`neuromaps_prime.analysis.stats` with
 operations that require surface topology.
 """
 
+from neuromaps_prime.analysis.surfaces import nulls
 from neuromaps_prime.analysis.surfaces.points import (
     get_surface_distance,
     make_surf_graph,
 )
 
-__all__ = ["get_surface_distance", "make_surf_graph"]
+__all__ = ["get_surface_distance", "make_surf_graph", "nulls"]

--- a/src/neuromaps_prime/analysis/surfaces/nulls/__init__.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/__init__.py
@@ -7,5 +7,22 @@ null distributions for statistical inference on brain surfaces.
 """
 
 from neuromaps_prime.analysis.surfaces.nulls import burt, spins
+from neuromaps_prime.analysis.surfaces.nulls.nulls import (
+    alexander_bloch,
+    baum,
+    burt2018,
+    cornblath,
+    hungarian,
+    vasa,
+)
 
-__all__ = ["burt", "spins"]
+__all__ = [
+    "alexander_bloch",
+    "baum",
+    "burt",
+    "burt2018",
+    "cornblath",
+    "hungarian",
+    "spins",
+    "vasa",
+]

--- a/src/neuromaps_prime/analysis/surfaces/nulls/__init__.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/__init__.py
@@ -5,3 +5,7 @@ preserve the autocorrelation properties of cortical data while destroying
 meaningful signal.  These surrogates form the basis of permutation-based
 null distributions for statistical inference on brain surfaces.
 """
+
+from neuromaps_prime.analysis.surfaces.nulls import burt, spins
+
+__all__ = ["burt", "spins"]

--- a/src/neuromaps_prime/analysis/surfaces/nulls/__init__.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/__init__.py
@@ -1,0 +1,7 @@
+"""Surrogate generation for null-distribution estimation.
+
+Provides methods for producing spatially structured surrogate maps that
+preserve the autocorrelation properties of cortical data while destroying
+meaningful signal.  These surrogates form the basis of permutation-based
+null distributions for statistical inference on brain surfaces.
+"""

--- a/src/neuromaps_prime/analysis/surfaces/nulls/burt.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/burt.py
@@ -1,0 +1,270 @@
+"""Surrogate map generation following Burt et al., 2018.
+
+Implements the spatial-autocorrelation-preserving surrogacy method from
+
+    Burt, S. M. et al. (2018). *Nature Neuroscience*, 21, pp. 642.
+
+The core idea is to generate surrogate cortical maps that preserve the
+spatial autocorrelation structure of the original data while destroying
+any meaningful signal.  This module provides the weight-matrix building
+block used by the higher-level Burt2018 surrogate pipeline.
+
+Adapted from the neuromaps codebase
+(https://github.com/netneurolab/neuromaps/blob/main/neuromaps/nulls/burt.py).
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import numpy as np
+from joblib import Parallel, delayed
+from scipy import sparse
+from scipy.linalg import lu_factor, lu_solve
+from scipy.optimize import least_squares
+from scipy.stats import boxcox
+
+__all__ = ["batch_surrogates", "estimate_rho_d0", "make_surrogate"]
+
+
+class SurrogateResult(NamedTuple):
+    """Result of surrogate map generation.
+
+    Attributes:
+        surrogate: The surrogate cortical map, shape ``(n,)``, preserving
+            the marginal distribution of the original data.
+        order: Rank-order array if ``return_order`` was ``True``,
+            otherwise ``None``.
+        params: The ``(rho, d0)`` tuple used to build the weight matrix
+            if ``return_params`` was ``True``, otherwise ``None``.
+    """
+
+    surrogate: np.ndarray
+    order: np.ndarray | None
+    params: tuple[float, float] | None
+
+
+def _make_weight_matrix(x: np.ndarray, d0: float) -> np.ndarray:
+    """Build a row-normalized spatial weight matrix from a distance matrix.
+
+    Each off-diagonal entry ``(i, j)`` receives an exponential-decay
+    weight ``exp(-d[i, j] / d0)`` where ``d0`` controls the scale of
+    spatial autocorrelation.  The diagonal is zeroed so that a vertex
+    never weighs against itself, then each row is normalized to sum to
+    one.
+
+    Args:
+        x: Square distance matrix of shape ``(n, n)``.  Values should
+            be non-negative distances (geodesic or Euclidean).
+        d0: Autocorrelation scale parameter.  Smaller values concentrate
+            weight on nearby neighbours; larger values spread weight more
+            diffusely.
+
+    Returns:
+        Row-normalized weight matrix of shape ``(n, n)`` with zeros on
+        the diagonal and each row summing to ``1.0``.
+
+    Note:
+        Overflow (``exp(-x/d0)`` when distances are very small relative
+        to ``d0``) and invalid (``0/0`` during row normalization) warnings
+        are suppressed because these edge cases resolve naturally under
+        numpy's floating-point semantics.
+    """
+    x = np.asarray(x)
+    with np.errstate(over="ignore"):
+        weight = np.exp(-x / d0)
+    np.fill_diagonal(weight, 0)
+
+    with np.errstate(invalid="ignore"):
+        return weight / weight.sum(axis=1, keepdims=True)
+
+
+def estimate_rho_d0(
+    x: np.ndarray, y: np.ndarray, *, rho: float | None = None, d0: float | None = None
+) -> tuple[float, float]:
+    """Estimate the spatial autoregressive parameters ``rho`` and ``d0``.
+
+    Fits a spatial autoregressive (SAR) model in which the expected
+    value of the data vector is ``rho * W(d0) @ y``, where ``W(d0)`` is
+    the row-normalized exponential-decay weight matrix built from the
+    distance matrix ``x`` and the scale parameter ``d0``.  The
+    Levenberg-Marquardt algorithm minimises the residual
+    ``y - rho * W @ y`` with respect to both ``rho`` and ``d0``.
+
+    Before optimisation the data vector is Box-Cox transformed to
+    approximate normality and centred by subtracting its mean.
+
+    Args:
+        x: Square distance matrix of shape ``(n, n)``.
+        y: 1-D brain-imaging data vector of length ``n``.  All values
+            must be strictly positive (requirement of the Box-Cox
+            transformation).
+        rho: Initial guess for the spatial autocorrelation coefficient.
+            If ``None`` defaults to ``1.0``, which assumes strong spatial
+            dependence.
+        d0: Initial guess for the spatial decay scale.  Controls the
+            distance over which neighbours remain influential.  If
+            ``None`` defaults to ``1.0``.
+
+    Returns:
+        A tuple of ``(rho_hat, d0_hat)`` — the fitted autocorrelation
+        coefficient and decay scale from the least-squares optimiser.
+    """
+
+    def _estimate(parameters: np.ndarray, x: np.ndarray, y: np.ndarray) -> np.ndarray:
+        """Compute residuals between observed and SAR-predicted values."""
+        rho_p, d0_p = parameters
+        y_hat = rho_p * (_make_weight_matrix(x, d0_p) @ y)
+        return y - y_hat
+
+    rho = 1.0 if rho is None else rho
+    d0 = 1.0 if d0 is None else d0
+
+    y, *_ = boxcox(y)
+    y -= y.mean()
+    result = least_squares(_estimate, [rho, d0], args=(x, y), method="lm")
+    return tuple(result.x)
+
+
+def make_surrogate(
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    rho: float | None = None,
+    d0: float | None = None,
+    seed: int | None = None,
+    return_order: bool = False,
+    return_params: bool = False,
+) -> SurrogateResult:
+    """Generate a single surrogate map that preserves spatial autocorrelation.
+
+    Solves ``(I - rho * W) s = u`` for a vector of standard-normal draws
+    ``u``, where ``W`` is the exponential-decay weight matrix built from
+    the distance matrix ``x``.  The raw solution is rank-ordered and then
+    the sorted values of ``y`` are assigned back, so the surrogate shares
+    the exact marginal distribution of the original data while retaining
+    its spatial autocorrelation structure.
+
+    Args:
+        x: Square distance matrix of shape ``(n, n)``.
+        y: 1-D brain-imaging data vector of length ``n``.
+        rho: Spatial autocorrelation coefficient.  If ``None`` will be
+            estimated from the data via :func:`estimate_rho_d0`.
+        d0: Spatial decay scale.  If ``None`` will be estimated from the
+            data via :func:`estimate_rho_d0`.
+        seed: Seed for the random number generator.  Set to ``None`` for
+            non-deterministic surrogates.
+        return_order: If ``True``, also return the rank-order array used
+            to rank-match the surrogate.
+        return_params: If ``True``, also return the ``(rho, d0)`` tuple
+            that was used to build the weight matrix.
+
+    Returns:
+        A :class:`SurrogateResult` namedtuple with fields:
+
+        - ``surrogate``: the surrogate map of shape ``(n,)``.
+        - ``order``: rank-order array if ``return_order`` is ``True``,
+          otherwise ``None``.
+        - ``params``: ``(rho, d0)`` tuple if ``return_params`` is ``True``,
+          otherwise ``None``.
+    """
+    rs = np.random.default_rng(seed)
+
+    if rho is None or d0 is None:
+        rho, d0 = estimate_rho_d0(x, y, rho=rho, d0=d0)
+
+    w = _make_weight_matrix(x, d0)
+    u = rs.standard_normal(len(x))
+    iw = -rho * w
+    np.fill_diagonal(iw, 1.0)
+    surr = np.linalg.solve(iw, u)
+
+    order = surr.argsort()
+    surr[order] = np.sort(y)
+    return SurrogateResult(
+        surrogate=surr,
+        order=order if return_order else None,
+        params=(rho, d0) if return_params else None,
+    )
+
+
+def batch_surrogates(
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    rho: float | None = None,
+    d0: float | None = None,
+    seed: int | None = None,
+    n_surr: int = 1_000,
+    n_jobs: int = 1,
+) -> np.ndarray:
+    """Generate multiple surrogate maps in parallel.
+
+    Estimates ``rho`` and ``d0`` once from the data, builds the system
+    matrix ``(I - rho * W)``, and then spawns ``n_surr`` independent
+    surrogate draws by solving the linear system.  If more than half the
+    entries of the system matrix are near-zero it is converted to a
+    sparse CSR matrix for faster solves.
+
+    Args:
+        x: Square distance matrix of shape ``(n, n)``.
+        y: 1-D brain-imaging data vector of length ``n``.
+        rho: Spatial autocorrelation coefficient.  If ``None`` will be
+            estimated from the data via :func:`estimate_rho_d0`.
+        d0: Spatial decay scale.  If ``None`` will be estimated from the
+            data via :func:`estimate_rho_d0`.
+        seed: Seed for the master random number generator used to produce
+            per-surrogate seeds.  Set to ``None`` for non-deterministic
+            surrogates.
+        n_surr: Number of surrogate maps to generate.
+        n_jobs: Number of parallel workers for surrogate generation.
+            Set to ``-1`` to use all available CPU cores.
+
+    Returns:
+        Array of shape ``(n, n_surr)`` where each column is an independent
+        surrogate map.
+    """
+
+    def _quick_surr(
+        iw_or_lu: tuple[np.ndarray, np.ndarray] | sparse.csr_matrix,
+        ysort: np.ndarray,
+        *,
+        seed: int,
+    ) -> np.ndarray:
+        """Generate a single surrogate given a system matrix or LU factorization."""
+        rs = np.random.default_rng(seed)
+        u = rs.standard_normal(len(ysort))
+        surr = (
+            sparse.linalg.spsolve(iw_or_lu, u)
+            if sparse.issparse(iw_or_lu)
+            else lu_solve(iw_or_lu, u)
+        )
+        surr[surr.argsort()] = ysort
+        return surr
+
+    if n_surr <= 0:
+        raise ValueError("n_surr must be positive")
+
+    rs = np.random.default_rng(seed)
+    seeds = rs.integers(np.iinfo(np.int32).max, size=n_surr, dtype=np.int32)
+
+    if rho is None or d0 is None:
+        rho, d0 = estimate_rho_d0(x, y, rho=rho, d0=d0)
+    iw = -rho * _make_weight_matrix(x, d0)
+    np.fill_diagonal(iw, 1.0)
+    zeros = np.isclose(iw, 0)
+    if (zeros.sum() / iw.size) > 0.5:
+        iw[zeros] = 0
+        iw = sparse.csr_matrix(iw)
+    else:
+        iw = lu_factor(iw)
+    ysort = np.sort(y)
+
+    if n_jobs != 1:
+        surrs = Parallel(n_jobs=n_jobs)(
+            delayed(_quick_surr)(iw, ysort, seed=seed) for seed in seeds
+        )
+    else:
+        surrs = [_quick_surr(iw, ysort, seed=seed) for seed in seeds]
+
+    return np.column_stack(surrs)

--- a/src/neuromaps_prime/analysis/surfaces/nulls/burt.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/burt.py
@@ -10,7 +10,7 @@ any meaningful signal.  This module provides the weight-matrix building
 block used by the higher-level Burt2018 surrogate pipeline.
 
 Adapted from the neuromaps codebase
-(https://github.com/netneurolab/neuromaps/blob/main/neuromaps/nulls/burt.py).
+(https://github.com/netneurolab/neuromaps/blob/ffcc2e0f657943ce00a1b6a968396f32250e495c/neuromaps/nulls/burt.py).
 """
 
 from __future__ import annotations

--- a/src/neuromaps_prime/analysis/surfaces/nulls/nulls.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/nulls.py
@@ -1,0 +1,554 @@
+"""Spatial null model convenience wrappers.
+
+Combines centroid computation, spin generation, and data permutation
+into single-call functions.  Adapted from neuromaps.
+"""
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Literal
+
+import nibabel as nib
+import numpy as np
+from numpy.typing import ArrayLike
+
+from neuromaps_prime.analysis.images import PARC_IGNORE, load_gifti
+from neuromaps_prime.analysis.surfaces.nulls.burt import batch_surrogates
+from neuromaps_prime.analysis.surfaces.nulls.spins import (
+    _get_parcel_centroids,
+    _to_hemisphere_list,
+    gen_spin_samples,
+    load_spins,
+    spin_data,
+    spin_parcels,
+)
+from neuromaps_prime.analysis.surfaces.points import get_surface_distance
+
+__all__ = ["alexander_bloch", "baum", "burt2018", "cornblath", "hungarian", "vasa"]
+
+_DataT = tuple[
+    str | Path | nib.GiftiImage,
+    str | Path | nib.GiftiImage,
+]
+_SpinMethod = Literal["original", "vasa", "hungarian"]
+_CentroidMethod = Literal["average", "surface", "geodesic"]
+
+
+def _resolve_data(
+    data: ArrayLike | str | Path | nib.GiftiImage | _DataT,
+    gifti_cache: dict[str | Path, nib.GiftiImage],
+) -> np.ndarray:
+    """Load *data* as a 1-D array, reusing cached GIFTI images."""
+
+    def _load_one(item: str | Path | nib.GiftiImage) -> np.ndarray:
+        if isinstance(item, nib.GiftiImage):
+            return item.agg_data().ravel()
+        img = gifti_cache.get(item)
+        if img is None:
+            img = load_gifti(item)
+        return img.agg_data().ravel()
+
+    if isinstance(data, tuple):
+        return np.hstack([_load_one(d) for d in data])
+    if isinstance(data, str | Path | nib.GiftiImage):
+        return _load_one(data)
+    return np.asarray(data, dtype=float).ravel()
+
+
+def _generate_spins(
+    surface: str | Path | tuple[str | Path, str | Path],
+    parcellation: str | Path | tuple[str | Path, str | Path] | None,
+    n_perm: int,
+    seed: int | None,
+    centroid_method: _CentroidMethod,
+    spin_method: _SpinMethod,
+    drop: Iterable[str],
+    gifti_cache: dict[str | Path, nib.GiftiImage],
+) -> tuple[np.ndarray, int]:
+    """Generate spin matrix from surface, returning (spin_matrix, n_elements)."""
+    surfaces_list = _to_hemisphere_list(surface)
+    parcellation_list = (
+        _to_hemisphere_list(parcellation) if parcellation is not None else []
+    )
+    if parcellation is not None and len(surfaces_list) != len(parcellation_list):
+        raise ValueError(
+            "Number of surface and parcellation files must match. "
+            f"Got {len(surfaces_list)} surface(s) and "
+            f"{len(parcellation_list)} parcellation(s)."
+        )
+
+    # Pre-load all GIFTI files once
+    for s in surfaces_list:
+        gifti_cache[s] = load_gifti(s)
+    for p in parcellation_list:
+        gifti_cache[p] = load_gifti(p)
+
+    centroid_list = []
+    hemi_list = []
+    for hemi, surf in enumerate(surfaces_list):
+        verts, faces = gifti_cache[surf].agg_data()
+        if hemi < len(parcellation_list):
+            parc_img = gifti_cache[parcellation_list[hemi]]
+            labels = parc_img.agg_data()
+            labeltable = parc_img.labeltable.get_labels_as_dict()
+            centroids = _get_parcel_centroids(
+                verts,
+                faces,
+                labels,
+                method=centroid_method,
+                drop=drop,
+                labeltable=labeltable,
+            )
+        else:
+            centroids = verts
+        centroid_list.append(centroids)
+        hemi_list.append(np.full(len(centroids), hemi, dtype=np.int8))
+
+    centroid_coords = np.vstack(centroid_list)
+    hemi_ids = np.hstack(hemi_list)
+    spin_matrix = gen_spin_samples(
+        centroid_coords,
+        hemi_ids,
+        n_rotate=n_perm,
+        method=spin_method,
+        seed=seed,
+    ).spin
+    return spin_matrix, len(centroid_coords)
+
+
+def _spin_permute(
+    data: ArrayLike | str | Path | nib.GiftiImage | _DataT | None,
+    surface: str | Path | tuple[str | Path, str | Path],
+    *,
+    parcellation: str | Path | tuple[str | Path, str | Path] | None,
+    n_perm: int,
+    seed: int | None,
+    spins: ArrayLike | None,
+    spin_method: _SpinMethod,
+    method: _CentroidMethod,
+    drop: Iterable[str],
+) -> np.ndarray:
+    """Core spin-permutation pipeline, shared by :func:`alexander_bloch`, etc."""
+    gifti_cache: dict[str | Path, nib.GiftiImage] = {}
+
+    if spins is not None:
+        spin_matrix = load_spins(spins)
+        n_elements = spin_matrix.shape[0]
+    else:
+        spin_matrix, n_elements = _generate_spins(
+            surface, parcellation, n_perm, seed, method, spin_method, drop, gifti_cache
+        )
+
+    if data is None:
+        return spin_matrix
+
+    data_array = _resolve_data(data, gifti_cache)
+    if len(data_array) != n_elements:
+        raise ValueError(
+            f"Data length ({len(data_array)}) does not match "
+            f"number of elements ({n_elements}) in the spin matrix."
+        )
+
+    return data_array[spin_matrix]
+
+
+def alexander_bloch(
+    data: ArrayLike | str | Path | nib.GiftiImage | _DataT | None,
+    surface: str | Path | tuple[str | Path, str | Path],
+    *,
+    parcellation: str | Path | tuple[str | Path, str | Path] | None = None,
+    n_perm: int = 1000,
+    seed: int | None = None,
+    spins: ArrayLike | None = None,
+    method: _CentroidMethod = "surface",
+    drop: Iterable[str] = PARC_IGNORE,
+) -> np.ndarray:
+    """Spin-permute data on a cortical surface.
+
+    Method projects data to a spherical surface and uses arbitrary
+    rotations to generate null distribution.  If *data* are parcellated
+    then parcel centroids are projected to surface and parcels are
+    reassigned based on minimum distances.
+
+    Args:
+        data: 1-D array of shape ``(n,)``, a GIFTI file path, a
+            ``nibabel.GiftiImage``, or ``(left, right)`` pair of any of
+            these.  If ``None``, returns the spin permutation matrix
+            instead of permuted data.
+        surface: Path to a single-hemisphere GIFTI surface file, or
+            ``(left, right)`` pair.
+        parcellation: Path to a single-hemisphere GIFTI label file, or
+            ``(left, right)`` pair.  If ``None``, *data* is vertex-level
+            and all vertices are used as centroids.
+        n_perm: Number of spin permutations. Default ``1000``.
+        seed: Random seed.
+        spins: Pre-computed ``(n, P)`` spin array. If provided, the
+            surface and parcellation arguments are ignored.
+        method: Centroid computation strategy. Default ``'surface'``.
+        drop: Label names to exclude. Default ``PARC_IGNORE``.
+
+    Returns:
+        Array of shape ``(n, n_perm)`` with spin-permuted data, or the
+        raw permutation indices if *data* is ``None``.
+
+    Raises:
+        ValueError: If *data* length does not match the number of
+            elements implied by the surface or parcellation.
+
+    References:
+        Alexander-Bloch et al. (2018). NeuroImage, 178, 540-51.
+    """
+    return _spin_permute(
+        data,
+        surface,
+        parcellation=parcellation,
+        n_perm=n_perm,
+        seed=seed,
+        spins=spins,
+        spin_method="original",
+        method=method,
+        drop=drop,
+    )
+
+
+def vasa(
+    data: ArrayLike | str | Path | nib.GiftiImage | _DataT | None,
+    surface: str | Path | tuple[str | Path, str | Path],
+    *,
+    parcellation: str | Path | tuple[str | Path, str | Path],
+    n_perm: int = 1000,
+    seed: int | None = None,
+    spins: ArrayLike | None = None,
+    method: _CentroidMethod = "surface",
+    drop: Iterable[str] = PARC_IGNORE,
+) -> np.ndarray:
+    """Spin-permute parcellated data using the Vasa assignment strategy.
+
+    Method projects parcels to a spherical surface and uses arbitrary
+    rotations with iterative reassignments to generate null distribution.
+    All nulls are "perfect" permutations of the input data (at the slight
+    expense of spatial topology).
+
+    Args:
+        data: 1-D array of shape ``(n,)``, a GIFTI file path, a
+            ``nibabel.GiftiImage``, or ``(left, right)`` pair of any of
+            these.  If ``None``, returns the spin permutation matrix
+            instead of permuted data.
+        surface: Path to a single-hemisphere GIFTI surface file, or
+            ``(left, right)`` pair.
+        parcellation: Path to a single-hemisphere GIFTI label file, or
+            ``(left, right)`` pair.  Must be provided.
+        n_perm: Number of spin permutations. Default ``1000``.
+        seed: Random seed.
+        spins: Pre-computed ``(n, P)`` spin array. If provided, the
+            surface and parcellation arguments are ignored.
+        method: Centroid computation strategy. Default ``'surface'``.
+        drop: Label names to exclude. Default ``PARC_IGNORE``.
+
+    Returns:
+        Array of shape ``(n, n_perm)`` with spin-permuted data, or the
+        raw permutation indices if *data* is ``None``.
+
+    Raises:
+        ValueError: If *parcellation* is not provided, or if *data*
+            length does not match the number of elements implied by the
+            surface or parcellation.
+
+    References:
+        Váša et al. (2018). Cerebral Cortex, 28(1), 281-294.
+    """
+    return _spin_permute(
+        data,
+        surface,
+        parcellation=parcellation,
+        n_perm=n_perm,
+        seed=seed,
+        spins=spins,
+        spin_method="vasa",
+        method=method,
+        drop=drop,
+    )
+
+
+def hungarian(
+    data: ArrayLike | str | Path | nib.GiftiImage | _DataT | None,
+    surface: str | Path | tuple[str | Path, str | Path],
+    *,
+    parcellation: str | Path | tuple[str | Path, str | Path],
+    n_perm: int = 1000,
+    seed: int | None = None,
+    spins: ArrayLike | None = None,
+    method: _CentroidMethod = "surface",
+    drop: Iterable[str] = PARC_IGNORE,
+) -> np.ndarray:
+    """Spin-permute parcellated data using the Hungarian assignment algorithm.
+
+    Method projects parcels to a spherical surface and uses arbitrary
+    rotations with iterative reassignments to generate null distribution.
+    All nulls are "perfect" permutations of the input data (at the slight
+    expense of spatial topology).
+
+    Args:
+        data: 1-D array of shape ``(n,)``, a GIFTI file path, a
+            ``nibabel.GiftiImage``, or ``(left, right)`` pair of any of
+            these.  If ``None``, returns the spin permutation matrix
+            instead of permuted data.
+        surface: Path to a single-hemisphere GIFTI surface file, or
+            ``(left, right)`` pair.
+        parcellation: Path to a single-hemisphere GIFTI label file, or
+            ``(left, right)`` pair.  Must be provided.
+        n_perm: Number of spin permutations. Default ``1000``.
+        seed: Random seed.
+        spins: Pre-computed ``(n, P)`` spin array. If provided, the
+            surface and parcellation arguments are ignored.
+        method: Centroid computation strategy. Default ``'surface'``.
+        drop: Label names to exclude. Default ``PARC_IGNORE``.
+
+    Returns:
+        Array of shape ``(n, n_perm)`` with spin-permuted data, or the
+        raw permutation indices if *data* is ``None``.
+
+    Raises:
+        ValueError: If *parcellation* is not provided, or if *data*
+            length does not match the number of elements implied by the
+            surface or parcellation.
+
+    References:
+        Kuhn (1955). Naval Research Logistics Quarterly, 2(1-2), 83-97.
+    """
+    return _spin_permute(
+        data,
+        surface,
+        parcellation=parcellation,
+        n_perm=n_perm,
+        seed=seed,
+        spins=spins,
+        spin_method="hungarian",
+        method=method,
+        drop=drop,
+    )
+
+
+def baum(
+    data: ArrayLike | str | Path | nib.GiftiImage | _DataT | None,
+    surface: str | Path | tuple[str | Path, str | Path],
+    *,
+    parcellation: str | Path | tuple[str | Path, str | Path],
+    n_perm: int = 1000,
+    seed: int | None = None,
+    spins: ArrayLike | None = None,
+    method: _CentroidMethod = "surface",
+) -> np.ndarray:
+    """Spin-permute parcellated data using the Baum max-overlap strategy.
+
+    Method projects *data* to spherical surface and uses arbitrary
+    rotations to generate null distributions.  Reassigned parcels are
+    based on the most common (i.e., modal) value of the vertices in
+    each parcel within the rotated data.
+
+    Args:
+        data: 1-D array of shape ``(n,)``, a GIFTI file path, a
+            ``nibabel.GiftiImage``, or ``(left, right)`` pair of any of
+            these.  If ``None``, returns the spin permutation matrix
+            instead of permuted data.
+        surface: Path to a single-hemisphere GIFTI surface file, or
+            ``(left, right)`` pair.
+        parcellation: Path to a single-hemisphere GIFTI label file, or
+            ``(left, right)`` pair.  Must be provided.
+        n_perm: Number of spin permutations. Default ``1000``.
+        seed: Random seed.
+        spins: Pre-computed ``(n_parcels, P)`` spin array. If provided,
+            the surface and parcellation arguments are ignored.
+        method: Centroid computation strategy. Default ``'surface'``.
+
+    Returns:
+        Array of shape ``(n_parcels, n_perm)`` with spin-permuted data.
+        Unmatched parcels are ``NaN``. Returns the raw permutation
+        indices if *data* is ``None``.
+
+    Raises:
+        ValueError: If *data* length does not match the number of
+            parcels implied by the parcellation.
+
+    References:
+        Baum et al. (2020). PNAS, 117(1), 771-778.
+    """
+    result = spin_parcels(
+        surface,
+        parcellation,
+        method=method,
+        n_rotate=n_perm,
+        spins=spins,
+        seed=seed,
+    )
+    spin_matrix = result.spin
+    n_parcels = spin_matrix.shape[0]
+
+    if data is None:
+        return spin_matrix
+
+    data_array = _resolve_data(data, {})
+    if len(data_array) != n_parcels:
+        raise ValueError(
+            f"Data length ({len(data_array)}) does not match "
+            f"number of parcels ({n_parcels})."
+        )
+
+    nulls = data_array[spin_matrix]
+    nulls[spin_matrix == -1] = np.nan
+    return nulls
+
+
+def cornblath(
+    data: ArrayLike | str | Path | nib.GiftiImage | _DataT,
+    surface: str | Path | tuple[str | Path, str | Path],
+    *,
+    parcellation: str | Path | tuple[str | Path, str | Path],
+    n_perm: int = 1000,
+    seed: int | None = None,
+    spins: ArrayLike | None = None,
+    method: _CentroidMethod = "surface",
+) -> np.ndarray:
+    """Spin-permute parcellated data using the Cornblath re-averaging strategy.
+
+    Method projects *data* to spherical surface and uses arbitrary
+    rotations to generate null distributions.  Reassigned parcels are
+    based on the average value of the vertices in each parcel within
+    the rotated data.
+
+    Args:
+        data: 1-D array of shape ``(n,)``, a GIFTI file path, a
+            ``nibabel.GiftiImage``, or ``(left, right)`` pair of any of
+            these.
+        surface: Path to a single-hemisphere GIFTI surface file, or
+            ``(left, right)`` pair.
+        parcellation: Path to a single-hemisphere GIFTI label file, or
+            ``(left, right)`` pair.  Must be provided.
+        n_perm: Number of spin permutations. Default ``1000``.
+        seed: Random seed.
+        spins: Pre-computed ``(n_parcels, P)`` spin array. If provided,
+            the surface and parcellation arguments are ignored.
+        method: Centroid computation strategy. Default ``'surface'``.
+
+    Returns:
+        Array of shape ``(n_parcels, n_perm)`` with spin-permuted data.
+        Values may differ slightly from the original due to re-averaging.
+
+    Raises:
+        ValueError: If *data* length does not match the number of
+            parcels implied by the parcellation.
+
+    References:
+        Cornblath et al. (2020). Communications Biology, 3(1), 1-12.
+    """
+    data_array = _resolve_data(data, {})
+    result = spin_data(
+        data_array,
+        surface,
+        parcellation,
+        method=method,
+        n_rotate=n_perm,
+        spins=spins,
+        seed=seed,
+    )
+    return result.spin
+
+
+def burt2018(
+    data: ArrayLike | str | Path | nib.GiftiImage | _DataT,
+    surface: str | Path | tuple[str | Path, str | Path],
+    *,
+    parcellation: str | Path | tuple[str | Path, str | Path] | None = None,
+    n_perm: int = 1000,
+    seed: int | None = None,
+    distmat: np.ndarray | tuple[np.ndarray, np.ndarray] | None = None,
+    n_proc: int = 1,
+) -> np.ndarray:
+    """Generate spatial surrogates using the Burt 2018 method (surface only).
+
+    Method uses a spatial auto-regressive model to estimate the
+    distance-dependent relationship of *data* and generates surrogate
+    maps with similar spatial autocorrelation properties.
+
+    Args:
+        data: 1-D array of shape ``(n,)``, a GIFTI file path, a
+            ``nibabel.GiftiImage``, or ``(left, right)`` pair of any of
+            these.
+        surface: Path to a single-hemisphere GIFTI surface file, or
+            ``(left, right)`` pair.
+        parcellation: Path to a single-hemisphere GIFTI label file, or
+            ``(left, right)`` pair. If ``None``, *data* is vertex-level.
+        n_perm: Number of surrogate maps to generate. Default ``1000``.
+        seed: Random seed.
+        distmat: Pre-computed distance matrix (single) or
+            ``(left, right)`` pair. If ``None``, distances are computed
+            from the surface.
+        n_proc: Number of parallel workers. Default ``1``.
+
+    Returns:
+        Array of shape ``(n, n_perm)`` with surrogate data.
+
+    Raises:
+        ValueError: If *data* length does not match the surface or
+            parcellation.
+
+    Note:
+        Surface-only implementation. Volumetric surrogates were not
+        adopted.
+
+    References:
+        Burt et al. (2018). Nature Neuroscience, 21(9), 1251-1259.
+    """
+    data_array = _resolve_data(data, {})
+    surfaces_list = _to_hemisphere_list(surface)
+    parcellation_list = (
+        _to_hemisphere_list(parcellation) if parcellation is not None else []
+    )
+    n_hemis = len(surfaces_list)
+    shift = np.abs(np.nanmin(data_array)) + 0.1
+    surrogates = np.full((len(data_array), n_perm), np.nan, dtype=float)
+
+    for hemi, surf in enumerate(surfaces_list):
+        hparc_path = (
+            parcellation_list[hemi]
+            if parcellation is not None and hemi < len(parcellation_list)
+            else None
+        )
+        if hparc_path is not None:
+            vertex_labels = load_gifti(hparc_path).agg_data()
+            parc_labels = np.trim_zeros(np.unique(vertex_labels)) - 1
+            hdata = data_array[parc_labels]
+            idx = parc_labels
+        elif n_hemis == 1:
+            hdata = data_array
+            idx = np.arange(len(data_array))
+        else:
+            lo, hi = hemi * (len(data_array) // 2), (hemi + 1) * (len(data_array) // 2)
+            hdata = data_array[lo:hi]
+            idx = np.arange(lo, hi)
+
+        if distmat is not None:
+            hdist = distmat[hemi] if isinstance(distmat, tuple) else distmat
+        else:
+            hdist = get_surface_distance(
+                surf,
+                parcellation=hparc_path,
+                drop=PARC_IGNORE,
+                n_proc=n_proc,
+            )
+        # Mask out medial wall (via ``drop=PARC_IGNORE``)
+        med = np.isinf(hdist + np.diag([np.inf] * len(hdist))).all(axis=1)
+        mask = ~np.logical_or(np.isnan(hdata), med)
+        hdata_masked = hdata[mask]
+        hdist_masked = hdist[np.ix_(mask, mask)]
+        hsl = idx[mask]
+        # Ensure data is positive for ``batch_surrogates``
+        hdata_masked = hdata_masked + shift
+
+        hsurr = batch_surrogates(
+            hdist_masked, hdata_masked, n_surr=n_perm, seed=seed, n_jobs=n_proc
+        )
+
+        surrogates[hsl, :] = hsurr
+
+    return surrogates

--- a/src/neuromaps_prime/analysis/surfaces/nulls/nulls.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/nulls.py
@@ -12,7 +12,7 @@ import nibabel as nib
 import numpy as np
 from numpy.typing import ArrayLike
 
-from neuromaps_prime.analysis.images import PARC_IGNORE, load_gifti
+from neuromaps_prime.analysis.images import PARC_IGNORE, load_gifti, relabel_gifti
 from neuromaps_prime.analysis.surfaces.nulls.burt import batch_surrogates
 from neuromaps_prime.analysis.surfaces.nulls.spins import (
     _get_parcel_centroids,
@@ -507,6 +507,7 @@ def burt2018(
     n_hemis = len(surfaces_list)
     shift = np.abs(np.nanmin(data_array)) + 0.1
     surrogates = np.full((len(data_array), n_perm), np.nan, dtype=float)
+    parcel_offset = 0
 
     for hemi, surf in enumerate(surfaces_list):
         hparc_path = (
@@ -515,10 +516,13 @@ def burt2018(
             else None
         )
         if hparc_path is not None:
-            vertex_labels = load_gifti(hparc_path).agg_data()
+            parc_img = relabel_gifti(hparc_path)
+            vertex_labels = parc_img.agg_data()
             parc_labels = np.trim_zeros(np.unique(vertex_labels)) - 1
-            hdata = data_array[parc_labels]
-            idx = parc_labels
+            # relabel_gifti makes labels per-hemisphere 1-indexed, so offset
+            idx = parc_labels + parcel_offset
+            hdata = data_array[idx]
+            parcel_offset += len(parc_labels)
         elif n_hemis == 1:
             hdata = data_array
             idx = np.arange(len(data_array))

--- a/src/neuromaps_prime/analysis/surfaces/nulls/spins.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/spins.py
@@ -570,7 +570,7 @@ def parcels_to_vertices(
             not match the size of *data*.
     """
     data = np.asarray(data, dtype=float)
-    data = np.vstack(data)
+    data = data[..., np.newaxis] if data.ndim == 1 else data
     parcellation_list = _to_hemisphere_list(parcellation)
     labels = np.hstack([load_gifti(parc).agg_data() for parc in parcellation_list])
     return _project_parcels_to_verts(data, labels)
@@ -714,7 +714,7 @@ def spin_data(
         )
 
     data = np.asarray(data, dtype=float)
-    data_2d = np.vstack(data) if data.ndim == 1 else data[..., np.newaxis]
+    data_2d = data[..., np.newaxis] if data.ndim == 1 else data
 
     # Load parcellation images once; reuse data + labeltables
     label_img_list = [load_gifti(parc) for parc in parcellation_list]

--- a/src/neuromaps_prime/analysis/surfaces/nulls/spins.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/spins.py
@@ -1,0 +1,784 @@
+"""Spatial rotation (spin) permutation utilities.
+
+Provides utilities for the spin permutation method: loading precomputed
+rotation matrices, computing parcel centroids from mesh geometry,
+generating random sphere rotations, building spin samples via various
+assignment methods, rotating parcellation boundaries, and projecting
+data between vertex and parcel levels.
+
+Spins preserve the large-scale spatial autocorrelation structure of
+cortical maps by rotating region boundaries across the sphere rather
+than shuffling values.
+
+Adapted from the neuromaps codebase
+(https://github.com/netneurolab/neuromaps/blob/ffcc2e0f657943ce00a1b6a968396f32250e495c/neuromaps/nulls/spins.py).
+"""
+
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Literal, NamedTuple
+
+import numpy as np
+from numpy.typing import ArrayLike
+from scipy import optimize, spatial
+from scipy.ndimage import labeled_comprehension
+
+from neuromaps_prime.analysis.images import PARC_IGNORE, load_gifti
+from neuromaps_prime.analysis.surfaces.points import _geodesic_parcel_centroid
+
+__all__ = [
+    "gen_spin_samples",
+    "get_parcel_centroids",
+    "load_spins",
+    "parcels_to_vertices",
+    "spin_data",
+    "spin_parcels",
+    "vertices_to_parcels",
+]
+
+
+_logger = logging.getLogger(__name__)
+
+
+def load_spins(fn: str | Path | ArrayLike, n_perm: int | None = None) -> np.ndarray:
+    """Load a spin permutation matrix from a file or array-like object.
+
+    Reads precomputed spin permutations from a NumPy ``.npy`` file,
+    comma-separated file, or array-like object.  Each column is a
+    permutation of vertex indices.
+
+    Args:
+        fn: Path to a ``.npy`` or comma-separated file, or an array-like
+            object.  For paths without the ``.npy`` suffix, the function
+            checks for a corresponding ``.npy`` file first, then falls
+            back to the text file.
+        n_perm: If provided, truncate to the first ``n_perm``
+            permutations along the last axis.
+
+    Returns:
+        Spin permutation array of shape ``(n, P)``.
+
+    Raises:
+        FileNotFoundError: If ``fn`` is a path and neither ``fn`` nor
+            ``fn.with_suffix('.npy')`` exists.
+    """
+    if not isinstance(fn, str | Path):
+        spins = np.asarray(fn, dtype=np.int32)
+    else:
+        fn = Path(fn)
+        npy_path = fn.with_suffix(".npy")
+
+        if npy_path.exists():
+            spins = np.load(npy_path, allow_pickle=False, mmap_mode="c")
+        elif fn.exists():
+            spins = np.loadtxt(fn, delimiter=",", dtype=np.int32)
+        else:
+            raise FileNotFoundError(f"Neither {fn} nor {npy_path} was found.")
+
+    if n_perm is not None:
+        spins = spins[..., :n_perm]
+    return spins
+
+
+def _get_parcel_centroids(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    labels: np.ndarray,
+    *,
+    method: Literal["average", "surface", "geodesic"] = "surface",
+    drop: Iterable[str] | None = None,
+    labeltable: dict[int, str] | None = None,
+) -> np.ndarray:
+    """Compute parcel centroids from pre-loaded arrays.
+
+    Core logic for :func:`get_parcel_centroids`.
+    """
+    if method not in (methods := frozenset(["average", "surface", "geodesic"])):
+        raise ValueError(f"Expected one of {methods} to be provided, got {method}")
+
+    drop_set = set(drop) if drop is not None else set()
+    if not drop_set:
+        labeltable = None
+
+    centroids = []
+    for lab in np.unique(labels):
+        if labeltable is not None and labeltable.get(lab) in drop_set:
+            continue
+
+        mask = labels == lab
+        if method in ("average", "surface"):
+            roi = vertices[mask].mean(axis=0)
+            if method == "surface":
+                idx = np.linalg.norm(vertices - roi, axis=1).argmin()
+                roi = vertices[idx]
+        elif method == "geodesic":
+            inds = np.nonzero(mask)[0]
+            roi = _geodesic_parcel_centroid(vertices=vertices, faces=faces, inds=inds)
+
+        centroids.append(roi)
+
+    return np.vstack(centroids)
+
+
+def get_parcel_centroids(
+    surface: str | Path,
+    *,
+    parcellation: str | Path | None = None,
+    method: Literal["average", "surface", "geodesic"] = "surface",
+    drop: Iterable[str] = PARC_IGNORE,
+) -> np.ndarray:
+    """Return vertex coordinates for each parcel centroid in a surface.
+
+    Computes centroid coordinates for every parcel defined in a
+    parcellation.  If *parcellation* is ``None``, returns all vertex
+    coordinates.
+
+    Args:
+        surface: Path to a GIFTI surface file.
+        parcellation: Path to a GIFTI label file defining parcels.
+            If ``None``, returns all vertex coordinates.
+        method: How to compute parcel centroids.  ``'average'`` uses
+            the arithmetic mean of vertex coordinates.  ``'surface'``
+            projects the mean to the nearest surface vertex.  ``'geodesic'``
+            finds the vertex with the minimum average geodesic distance
+            to all other vertices in the parcel (slower).
+            Default is ``'surface'``.
+        drop: Iterable of label names to skip.  Defaults to
+            :data:`~neuromaps_prime.analysis.surfaces.points.PARC_IGNORE`
+            which excludes unknown and medial-wall regions.
+
+    Returns:
+        Array of shape ``(n, 3)``.  If *parcellation* was provided,
+        ``n`` is the number of parcels (minus dropped labels);
+        otherwise ``n`` is the vertex count.
+
+    Raises:
+        ValueError: If *method* is not one of the recognised values.
+        FileNotFoundError: If *surface* or *parcellation* do not exist.
+    """
+    vertices, faces = load_gifti(surface).agg_data()
+
+    if parcellation is None:
+        return vertices
+
+    label_data = load_gifti(parcellation)
+    labels = label_data.agg_data()
+    labeltable = label_data.labeltable.get_labels_as_dict()
+
+    return _get_parcel_centroids(
+        vertices, faces, labels, method=method, drop=drop, labeltable=labeltable
+    )
+
+
+class Rotation(NamedTuple):
+    """Hemispheric rotation matrix pair.
+
+    Attributes:
+        left:  ``(3, 3)`` orthogonal rotation matrix for the left
+            hemisphere.
+        right: ``(3, 3)`` orthogonal rotation matrix for the right
+            hemisphere, obtained by reflecting *left* across the Y-Z
+            plane so that both hemispheres rotate coherently.
+    """
+
+    left: np.ndarray
+    right: np.ndarray
+
+
+def _gen_rotation(seed: int | None = None) -> Rotation:
+    """Generate a random orthogonal rotation matrix for spherical coordinates.
+
+    Produces a uniform random ``(3, 3)`` rotation matrix via QR decomposition,
+    corrects the determinant, then reflects across the Y-Z plane for the
+    right hemisphere.
+
+    Args:
+        seed: Seed for the random number generator.
+
+    Returns:
+        A :class:`Rotation` namedtuple with ``left`` and ``right``
+        ``(3, 3)`` rotation matrices.
+    """
+    rs = np.random.default_rng(seed)
+    reflect_x = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    rot_l, temp = np.linalg.qr(rs.normal(size=(3, 3)))
+    rot_l = rot_l @ np.diag(np.sign(np.diag(temp)))
+    if np.linalg.det(rot_l) < 0:
+        rot_l[:, 0] = -rot_l[:, 0]
+
+    rot_r = reflect_x @ rot_l @ reflect_x
+
+    return Rotation(left=rot_l, right=rot_r)
+
+
+def _validate_spin_inputs(
+    coords: np.ndarray,
+    hemi_id: np.ndarray,
+) -> None:
+    """Validate shape and hemisphere designation arrays."""
+    if coords.shape[-1] != 3 or coords.squeeze().ndim != 2:
+        raise ValueError(
+            f"Provided `coords` must be of shape (N, 3), not {coords.shape}"
+        )
+    if hemi_id.ndim != 1:
+        raise ValueError("Provided `hemi_id` array must be one-dimensional.")
+    if len(coords) != len(hemi_id):
+        raise ValueError(
+            f"Provided `coords` and `hemi_id` must have the same "
+            f"length. Provided lengths: coords={len(coords)}, hemi_id={len(hemi_id)}"
+        )
+    if np.max(hemi_id) > 1 or np.min(hemi_id) < 0:
+        raise ValueError(
+            f"hemi_id must have values in {{0, 1}} denoting left and "
+            f"right hemisphere coordinates, respectively. "
+            f"Provided array contains values: {np.unique(hemi_id)}"
+        )
+
+
+class SpinResult(NamedTuple):
+    """Result of spin sample generation.
+
+    Attributes:
+        spin: ``(N, P)`` resampling array where each column is a
+            permutation of vertex indices.
+        cost: ``(N, P)`` array of Euclidean reassignment distances
+            if ``return_cost`` was ``True``, otherwise ``None``.
+    """
+
+    spin: np.ndarray
+    cost: np.ndarray | None
+
+
+def _assign_coordinates(
+    coor: np.ndarray,
+    rotated: np.ndarray,
+    method: Literal["original", "vasa", "hungarian"],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Match rotated coordinates to original grid."""
+    n = len(coor)
+    if method == "original":
+        dist, col = spatial.KDTree(rotated).query(coor, 1)
+        return col, dist
+    if method == "vasa":
+        dist = spatial.distance_matrix(coor, rotated)
+        col = np.zeros(n, dtype=np.int32)
+        costs = np.empty(n)
+        for _ in range(n):
+            row = dist.min(axis=1).argmax()
+            col[row] = dist[row].argmin()
+            costs[row] = dist[row, col[row]]
+            dist[row] = -np.inf
+            dist[:, col[row]] = np.inf
+        return col, costs
+    # optimization of total cost uusing Hungarian algorithm; may result in
+    # certain parcels having higher cost (relativa to 'vasa'), but total
+    # cost should always be lower
+    if method == "hungarian":
+        dist = spatial.distance_matrix(coor, rotated)
+        row, col = optimize.linear_sum_assignment(dist)
+        costs = np.empty(n)
+        costs[row] = dist[row, col]
+        return col, costs
+    raise ValueError(f"Unknown method: {method}")
+
+
+def gen_spin_samples(
+    coords: ArrayLike,
+    hemi_id: ArrayLike,
+    *,
+    n_rotate: int = 1000,
+    method: Literal["original", "vasa", "hungarian"] = "original",
+    check_duplicates: bool = True,
+    seed: int | None = None,
+    return_cost: bool = False,
+) -> SpinResult:
+    """Generate spin permutation samples by randomly rotating coordinates.
+
+    Applies random rotations to *coords* on the unit sphere to produce a
+    resampling array that preserves the spatial embedding of the original
+    coordinates.  Rotations are generated for one hemisphere and mirrored
+    across the Y-Z plane for the other via :func:`_gen_rotation`.
+
+    Args:
+        coords: ``(N, 3)`` array of X, Y, Z coordinates for ``N`` nodes,
+            parcels, or vertices.
+        hemi_id: ``(N,)`` array of hemisphere designations as ``{0, 1}``.
+        n_rotate: Number of rotations to generate. Default is ``1000``.
+        method: Strategy for matching rotated coordinates back to the
+            original grid.  ``'original'`` uses a KD-tree
+            (memory-efficient but may assign multiple coordinates to the
+            same target).  ``'vasa'`` uses a greedy min-max assignment.
+            ``'hungarian'`` uses the Hungarian algorithm for optimal
+            assignment. Default is ``'original'``.
+        check_duplicates: If ``True``, retry rotations (up to 500 times)
+            to ensure each spin is unique and not identical to the input.
+            Default is ``True``.
+        seed: Seed for the random number generator.
+        return_cost: If ``True``, populate the ``cost`` field with the
+            Euclidean reassignment distances. Default is ``False``.
+
+    Returns:
+        A :class:`SpinResult` namedtuple with ``(N, n_rotate)`` spin
+        array and optional cost array.
+
+    Raises:
+        ValueError: If *coords* is not ``(N, 3)``, *hemi_id* is not
+            ``(N,)``, or *method* is not recognised.
+    """
+    if method not in (methods := frozenset(["original", "vasa", "hungarian"])):
+        raise ValueError(
+            f"Provided method '{method}' invalid. Must be one of {methods}."
+        )
+
+    coords = np.asanyarray(coords)
+    hemi_id = np.squeeze(np.asanyarray(hemi_id, dtype=np.int8))
+    _validate_spin_inputs(coords=coords, hemi_id=hemi_id)
+
+    n_coords = len(coords)
+    spin = np.zeros((n_coords, n_rotate), dtype=np.int32)
+    cost = np.zeros((n_coords, n_rotate), dtype=np.float64) if return_cost else None
+    inds = np.arange(n_coords, dtype=np.int32)
+    seen: set[tuple[np.int32, ...]] | None = set() if check_duplicates else None
+
+    rs = np.random.default_rng(seed)
+    warned = False
+    for k in range(n_rotate):
+        count, duplicated = 0, True
+
+        _logger.info("Generating spin %5d of %d", k, n_rotate)
+
+        while duplicated and count < 500:
+            count += 1
+            duplicated = False
+            resampled = np.zeros(n_coords, dtype=np.int32)
+
+            # Mirrored rotation pair for both hemispheres, rotating separately
+            for h, rot in enumerate(
+                _gen_rotation(seed=rs.integers(0, np.iinfo(np.int32).max, dtype=int))
+            ):
+                hinds = hemi_id == h
+                coor = coords[hinds]
+                if coor.size == 0:
+                    continue
+
+                rotated = coor @ rot
+                col, costs = _assign_coordinates(coor, rotated, method)
+                resampled[hinds] = inds[hinds][col]
+                if cost is not None:
+                    cost[hinds, k] = costs
+
+            if seen is not None:
+                resampled_tuple = tuple(resampled)
+                duplicated = bool(resampled_tuple in seen or np.all(resampled == inds))
+
+        if count == 500 and not warned:
+            _logger.warning(
+                "Duplicate rotations used. Check resampling array to determine "
+                "real number of unique permutations.",
+                stacklevel=2,
+            )
+            warned = True
+
+        spin[:, k] = resampled
+        if seen is not None:
+            seen.add(tuple(resampled))
+
+    return SpinResult(spin=spin, cost=cost)
+
+
+def _max_overlap(vals: np.ndarray) -> int:
+    """Return the most common positive label in *vals* minus 1, or -1 if none.
+
+    The ``-1`` offset maps consecutive 1-based parcel labels to
+    0-based row indices for :func:`ndimage.labeled_comprehension`.
+    """
+    vals, counts = np.unique(vals[vals > 0], return_counts=True)
+    try:
+        return int(vals[counts.argmax()]) - 1
+    except IndexError:
+        return -1
+
+
+def _to_hemisphere_list(
+    item: str | Path | tuple[str | Path, str | Path],
+) -> list[str | Path]:
+    """Normalise *item* to a list of one or two file paths."""
+    if isinstance(item, str | Path):
+        return [item]
+    return list(item)
+
+
+def spin_parcels(
+    surfaces: str | Path | tuple[str | Path, str | Path],
+    parcellation: str | Path | tuple[str | Path, str | Path],
+    *,
+    method: Literal["average", "surface", "geodesic"] = "surface",
+    n_rotate: int = 1000,
+    spins: ArrayLike | None = None,
+    seed: int | None = None,
+    return_cost: bool = False,
+    **kwargs: Any,  # noqa: ANN401 kwargs passed to :func:`gen_spin_samples`
+) -> SpinResult:
+    """Rotate parcel boundaries and reassign by maximum overlap.
+
+    Vertex-level labels are rotated and each *parcel* is reassigned
+    based on the region that maximally overlaps with its boundaries.
+    This produces a resampling matrix for permuting parcel-level data
+    while preserving spatial autocorrelation.
+
+    Args:
+        surfaces: Path to a single GIFTI surface file or ``(left,
+            right)`` pair. Spherical surfaces are recommended.
+        parcellation: Path to a single GIFTI label file or ``(left,
+            right)`` pair containing parcel labels on the
+            corresponding surface(s).
+        method: How to compute parcel centroids for spin generation.
+            Passed to :func:`get_parcel_centroids`. Default is
+            ``'surface'``.
+        n_rotate: Number of rotations to generate. Default is ``1000``.
+        spins: Pre-computed spin permutations to use instead of
+            generating them on the fly. If provided, *surfaces*,
+            *method*, *n_rotate*, and *seed* are ignored. Default is
+            ``None``.
+        seed: Seed for random number generation.
+        return_cost: Whether to return the cost array (Euclidean
+            reassignment distances). Default is ``False``.
+        **kwargs: Additional keyword arguments passed to
+            :func:`gen_spin_samples`.
+
+    Returns:
+        :class:`SpinResult` with ``(n_parcels, P)`` resampling array
+        and optional ``(n_coords, P)`` cost array.
+
+    Raises:
+        ValueError: If the parcellation and surface have mismatched
+            vertex counts.
+
+    Note:
+        Background label (0) is excluded from the output. The row
+        order corresponds to the sorted unique non-zero parcel labels.
+    """
+    surfaces_list = _to_hemisphere_list(surfaces)
+    parcellation_list = _to_hemisphere_list(parcellation)
+
+    if len(surfaces_list) != len(parcellation_list):
+        raise ValueError(
+            "Number of surface and parcellation files must match. "
+            f"Got {len(surfaces_list)} surface(s) and "
+            f"{len(parcellation_list)} parcellation(s)."
+        )
+
+    vertex_labels = np.hstack(
+        [load_gifti(parc).agg_data() for parc in parcellation_list]
+    )
+    label_values = np.unique(vertex_labels)
+    parcel_mask = label_values != 0
+    n_vertices = len(vertex_labels)
+    n_parcels = int(parcel_mask.sum())
+
+    if spins is None:
+        centroid_list = []
+        hemi_list = []
+        for hemi, (surf, parc) in enumerate(
+            zip(surfaces_list, parcellation_list, strict=True)
+        ):
+            centroids = get_parcel_centroids(surf, parcellation=parc, method=method)
+            centroid_list.append(centroids)
+            hemi_list.append(np.full(len(centroids), hemi, dtype=np.int8))
+        centroid_coords = np.vstack(centroid_list)
+        hemi_ids = np.hstack(hemi_list)
+
+        result = gen_spin_samples(
+            centroid_coords,
+            hemi_ids,
+            n_rotate=n_rotate,
+            seed=seed,
+            return_cost=return_cost,
+            **kwargs,
+        )
+        spin_perm = result.spin
+        cost = result.cost
+    else:
+        spin_perm = load_spins(spins)
+        cost = None
+
+    n_spins = spin_perm.shape[1]
+
+    if n_vertices != len(spin_perm):
+        raise ValueError(
+            f"Parcellation vertex count ({n_vertices}) does not match "
+            f"spin array length ({len(spin_perm)})"
+        )
+
+    regions = np.zeros((n_parcels, n_spins), dtype=np.int32)
+    for spin_idx in range(n_spins):
+        _logger.info("Calculating parcel overlap: %5d/%d", spin_idx, n_spins)
+        regions[:, spin_idx] = labeled_comprehension(
+            vertex_labels[spin_perm[:, spin_idx]],
+            vertex_labels,
+            label_values,
+            _max_overlap,
+            np.int32,
+            -1,
+        )[parcel_mask]
+
+    return SpinResult(spin=regions, cost=cost if return_cost else None)
+
+
+def _project_parcels_to_verts(data: np.ndarray, labels: np.ndarray) -> np.ndarray:
+    """Project parcel-level data to vertices given pre-loaded labels."""
+    n_parcels = int(labels.max())
+
+    if n_parcels != data.shape[0]:
+        raise ValueError(
+            f"Number of parcels ({n_parcels}) does not match "
+            f"data shape ({data.shape[0]})."
+        )
+
+    # Prepend NaN row for background (label 0); data[labels] fills
+    # background vertices with NaN
+    return np.vstack([np.full((1, data.shape[1]), np.nan), data])[labels, :].squeeze()
+
+
+def parcels_to_vertices(
+    data: ArrayLike, parcellation: str | Path | tuple[str | Path, str | Path]
+) -> np.ndarray:
+    """Project parcellated *data* to vertices.
+
+    Each vertex receives the value of the parcel it belongs to.
+    Background vertices (label 0) are filled with ``NaN``.
+
+    Args:
+        data: Parcellated data.  A 1-D array ``(n_parcels,)`` or 2-D
+            ``(n_parcels, n_features)``.  For dual-hemisphere inputs,
+            parcel labels must share the same numeric range across
+            hemispheres.
+        parcellation: Path to a single GIFTI label file or ``(left,
+            right)`` pair.  Label indices must be consecutive integers
+            starting at 1 (background is 0). Use
+            :func:`~neuromaps_prime.analysis.images.relabel_gifti` to
+            ensure consecutive labeling.
+
+    Returns:
+        Vertex-level data of shape ``(n_vertices,)`` or
+        ``(n_vertices, n_features)``.  If both hemispheres are
+        provided, vertex order is ``[left, right]``.  Singleton
+        trailing dimensions are squeezed.
+
+    Raises:
+        ValueError: If the number of parcels in the parcellation does
+            not match the size of *data*.
+    """
+    data = np.asarray(data, dtype=float)
+    data = np.atleast_2d(data)
+    parcellation_list = _to_hemisphere_list(parcellation)
+    labels = np.hstack([load_gifti(parc).agg_data() for parc in parcellation_list])
+    return _project_parcels_to_verts(data, labels)
+
+
+def _reduce_vertices_to_parcels(
+    data: np.ndarray,
+    labels: np.ndarray,
+    *,
+    parcel_values: np.ndarray,
+    background: float | None = None,
+) -> np.ndarray:
+    """Reduce vertex-level data to parcels given pre-loaded labels.
+
+    Core logic for :func:`vertices_to_parcels`.
+    """
+    if background is not None:
+        data = data.copy()
+        data[data == background] = np.nan
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        reduced = np.array(
+            [np.nanmean(data[labels == lab], axis=0) for lab in parcel_values],
+            dtype=float,
+        )
+
+    # Strip background parcel (label 0)
+    return reduced[parcel_values != 0].squeeze()
+
+
+def vertices_to_parcels(
+    data: ArrayLike,
+    parcellation: str | Path | tuple[str | Path, str | Path],
+    *,
+    background: float | None = None,
+) -> np.ndarray:
+    """Reduce vertex-level *data* to parcels.
+
+    Computes the mean of *data* within each parcel, ignoring vertices
+    that are ``NaN`` or equal to *background*.  Parcels whose vertices
+    are all ``NaN`` or *background* receive ``NaN``.
+
+    Args:
+        data: Vertex-level data.  A 1-D array ``(n_vertices,)`` or 2-D
+            ``(n_vertices, n_features)``.  For dual-hemisphere inputs,
+            vertex order should be ``[left, right]``.
+        parcellation: Path to a single GIFTI label file or ``(left,
+            right)`` pair defining parcels.
+        background: Optional value to treat as background and ignore
+            when computing means.  Default is ``None``.
+
+    Returns:
+        Parcellated data of shape ``(n_parcels,)`` or
+        ``(n_parcels, n_features)``.  Singleton trailing dimensions
+        are squeezed.  Background parcels (label 0) are excluded.
+
+    Raises:
+        ValueError: If the number of vertices in the parcellation does
+            not match the size of *data*.
+    """
+    data = np.asarray(data, dtype=float)
+    data = np.expand_dims(data, axis=-1) if data.ndim == 1 else data
+
+    parcellation_list = _to_hemisphere_list(parcellation)
+    labels = np.hstack([load_gifti(p).agg_data() for p in parcellation_list])
+
+    if data.shape[0] != len(labels):
+        raise ValueError(
+            f"Vertex count ({len(labels)}) does not match data shape ({data.shape[0]})."
+        )
+
+    parcel_values = np.unique(labels)
+    return _reduce_vertices_to_parcels(
+        data, labels, parcel_values=parcel_values, background=background
+    )
+
+
+def spin_data(
+    data: ArrayLike,
+    surfaces: str | Path | tuple[str | Path, str | Path],
+    parcellation: str | Path | tuple[str | Path, str | Path],
+    *,
+    method: Literal["average", "surface", "geodesic"] = "surface",
+    n_rotate: int = 1000,
+    spins: ArrayLike | None = None,
+    seed: int | None = None,
+    return_cost: bool = False,
+    **kwargs: Any,  # noqa: ANN401 kwargs passed to :func:`gen_spin_samples`
+) -> SpinResult:
+    """Spin parcellated *data* by rotating parcel boundaries on a surface.
+
+    Projects parcel data to vertices, applies random spherical
+    rotations, then re-averages back to the parcel level.  Re-averaging
+    means spun values will differ slightly from the original; parcels
+    whose vertices fall entirely within background regions receive
+    ``NaN``.
+
+    Args:
+        data: 1-D array of shape ``(n_parcels,)`` indexed by parcel
+            label value (``data[0]`` is label 1, ``data[1]`` is label 2,
+            etc.).
+        surfaces: Path to a single GIFTI surface file or ``(left,
+            right)`` pair. Spherical surfaces are recommended.
+        parcellation: Path to a single GIFTI label file or ``(left,
+            right)`` pair containing parcel labels on the
+            corresponding surface(s).
+        method: How to compute parcel centroids for spin generation.
+            Passed to :func:`get_parcel_centroids`. Default is
+            ``'surface'``.
+        n_rotate: Number of rotations to generate. Default is ``1000``.
+        spins: Pre-computed spin permutations to use instead of
+            generating them on the fly. If provided, *surfaces*,
+            *method*, *n_rotate*, and *seed* are ignored. Default is
+            ``None``.
+        seed: Seed for random number generation.
+        return_cost: Whether to return the cost array (Euclidean
+            reassignment distances). Default is ``False``.
+        **kwargs: Additional keyword arguments passed to
+            :func:`gen_spin_samples`.
+
+    Returns:
+        :class:`SpinResult` with ``(n_parcels, n_rotate)`` spin array
+        and optional ``(n_coords, n_rotate)`` cost array.
+
+    Raises:
+        ValueError: If the parcellation and surface have mismatched
+            vertex counts.
+
+    Note:
+        Background parcels (label 0) are excluded from the output.
+        When both hemispheres are provided, the parcel mean is computed
+        across all vertices sharing that label value in both hemispheres.
+    """
+    surfaces_list = _to_hemisphere_list(surfaces)
+    parcellation_list = _to_hemisphere_list(parcellation)
+    if len(surfaces_list) != len(parcellation_list):
+        raise ValueError(
+            "Number of surface and parcellation files must match. "
+            f"Got {len(surfaces_list)} surface(s) and "
+            f"{len(parcellation_list)} parcellation(s)."
+        )
+
+    data = np.asarray(data, dtype=float)
+    data_2d = np.atleast_2d(data)
+
+    # Load parcellation images once; reuse data + labeltables
+    label_img_list = [load_gifti(parc) for parc in parcellation_list]
+    label_list = [img.agg_data() for img in label_img_list]
+    labeltable_list = [img.labeltable.get_labels_as_dict() for img in label_img_list]
+    combined_labels = np.hstack(label_list)
+    parcel_values = np.unique(combined_labels)
+    parcel_mask = parcel_values != 0
+
+    vertex_data = np.hstack(
+        [_project_parcels_to_verts(data_2d, label) for label in label_list]
+    )
+
+    if spins is None:
+        surface_list = [load_gifti(surf).agg_data() for surf in surfaces_list]
+
+        centroid_list = []
+        hemi_list = []
+        for hemi, ((vert, faces), label, labeltable) in enumerate(
+            zip(surface_list, label_list, labeltable_list, strict=True)
+        ):
+            centroids = _get_parcel_centroids(
+                vert,
+                faces,
+                label,
+                method=method,
+                drop=PARC_IGNORE,
+                labeltable=labeltable,
+            )
+            centroid_list.append(centroids)
+            hemi_list.append(np.full(len(centroids), hemi, dtype=np.int8))
+        centroid_coords = np.vstack(centroid_list)
+        hemi_ids = np.hstack(hemi_list)
+
+        result = gen_spin_samples(
+            centroid_coords,
+            hemi_ids,
+            n_rotate=n_rotate,
+            seed=seed,
+            return_cost=return_cost,
+            **kwargs,
+        )
+        spin_arr = result.spin
+        cost = result.cost
+    else:
+        spin_arr = load_spins(spins)
+        cost = None
+
+    n_vert = len(vertex_data)
+    if n_vert != len(spin_arr):
+        raise ValueError(
+            f"Vertex count ({n_vert}) does not match "
+            f"spin array length ({len(spin_arr)})"
+        )
+
+    spun = np.zeros((int(parcel_mask.sum()), len(spin_arr)), dtype=float)
+    for spin_idx in range(n_rotate):
+        _logger.info("Reducing vertices to parcels: %5d/%d", spin_idx, n_rotate)
+        rotated = vertex_data[spin_arr[:, spin_idx]]
+        reduced = _reduce_vertices_to_parcels(
+            rotated, combined_labels, parcel_values=parcel_values
+        )
+        spun[:, spin_idx] = reduced
+
+    return SpinResult(spin=spun, cost=cost)

--- a/src/neuromaps_prime/analysis/surfaces/nulls/spins.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/spins.py
@@ -145,7 +145,7 @@ def get_parcel_centroids(
             to all other vertices in the parcel (slower).
             Default is ``'surface'``.
         drop: Iterable of label names to skip.  Defaults to
-            :data:`~neuromaps_prime.analysis.surfaces.points.PARC_IGNORE`
+            :data:`~neuromaps_prime.analysis.images.PARC_IGNORE`
             which excludes unknown and medial-wall regions.
 
     Returns:

--- a/src/neuromaps_prime/analysis/surfaces/nulls/spins.py
+++ b/src/neuromaps_prime/analysis/surfaces/nulls/spins.py
@@ -262,7 +262,7 @@ def _assign_coordinates(
         dist, col = spatial.KDTree(rotated).query(coor, 1)
         return col, dist
     if method == "vasa":
-        dist = spatial.distance_matrix(coor, rotated)
+        dist = spatial.distance.cdist(coor, rotated)
         col = np.zeros(n, dtype=np.int32)
         costs = np.empty(n)
         for _ in range(n):
@@ -276,7 +276,7 @@ def _assign_coordinates(
     # certain parcels having higher cost (relativa to 'vasa'), but total
     # cost should always be lower
     if method == "hungarian":
-        dist = spatial.distance_matrix(coor, rotated)
+        dist = spatial.distance.cdist(coor, rotated)
         row, col = optimize.linear_sum_assignment(dist)
         costs = np.empty(n)
         costs[row] = dist[row, col]
@@ -397,7 +397,7 @@ def _max_overlap(vals: np.ndarray) -> int:
     vals, counts = np.unique(vals[vals > 0], return_counts=True)
     try:
         return int(vals[counts.argmax()]) - 1
-    except IndexError:
+    except (IndexError, ValueError):
         return -1
 
 
@@ -481,10 +481,8 @@ def spin_parcels(
     if spins is None:
         centroid_list = []
         hemi_list = []
-        for hemi, (surf, parc) in enumerate(
-            zip(surfaces_list, parcellation_list, strict=True)
-        ):
-            centroids = get_parcel_centroids(surf, parcellation=parc, method=method)
+        for hemi, surf in enumerate(surfaces_list):
+            centroids = get_parcel_centroids(surf, method=method)
             centroid_list.append(centroids)
             hemi_list.append(np.full(len(centroids), hemi, dtype=np.int8))
         centroid_coords = np.vstack(centroid_list)
@@ -572,7 +570,7 @@ def parcels_to_vertices(
             not match the size of *data*.
     """
     data = np.asarray(data, dtype=float)
-    data = np.atleast_2d(data)
+    data = np.vstack(data)
     parcellation_list = _to_hemisphere_list(parcellation)
     labels = np.hstack([load_gifti(parc).agg_data() for parc in parcellation_list])
     return _project_parcels_to_verts(data, labels)
@@ -716,36 +714,22 @@ def spin_data(
         )
 
     data = np.asarray(data, dtype=float)
-    data_2d = np.atleast_2d(data)
+    data_2d = np.vstack(data) if data.ndim == 1 else data[..., np.newaxis]
 
     # Load parcellation images once; reuse data + labeltables
     label_img_list = [load_gifti(parc) for parc in parcellation_list]
     label_list = [img.agg_data() for img in label_img_list]
-    labeltable_list = [img.labeltable.get_labels_as_dict() for img in label_img_list]
     combined_labels = np.hstack(label_list)
     parcel_values = np.unique(combined_labels)
     parcel_mask = parcel_values != 0
 
-    vertex_data = np.hstack(
-        [_project_parcels_to_verts(data_2d, label) for label in label_list]
-    )
+    vertex_data = _project_parcels_to_verts(data_2d, combined_labels)
 
     if spins is None:
-        surface_list = [load_gifti(surf).agg_data() for surf in surfaces_list]
-
         centroid_list = []
         hemi_list = []
-        for hemi, ((vert, faces), label, labeltable) in enumerate(
-            zip(surface_list, label_list, labeltable_list, strict=True)
-        ):
-            centroids = _get_parcel_centroids(
-                vert,
-                faces,
-                label,
-                method=method,
-                drop=PARC_IGNORE,
-                labeltable=labeltable,
-            )
+        for hemi, surf in enumerate(surfaces_list):
+            centroids = get_parcel_centroids(surf, method=method)
             centroid_list.append(centroids)
             hemi_list.append(np.full(len(centroids), hemi, dtype=np.int8))
         centroid_coords = np.vstack(centroid_list)
@@ -772,7 +756,7 @@ def spin_data(
             f"spin array length ({len(spin_arr)})"
         )
 
-    spun = np.zeros((int(parcel_mask.sum()), len(spin_arr)), dtype=float)
+    spun = np.zeros((int(parcel_mask.sum()), spin_arr.shape[1]), dtype=float)
     for spin_idx in range(n_rotate):
         _logger.info("Reducing vertices to parcels: %5d/%d", spin_idx, n_rotate)
         rotated = vertex_data[spin_arr[:, spin_idx]]

--- a/src/neuromaps_prime/analysis/surfaces/points.py
+++ b/src/neuromaps_prime/analysis/surfaces/points.py
@@ -8,7 +8,7 @@ topology to support spatial operations that have no CTF or workbench
 equivalent (e.g., Dijkstra-based shortest-path distance on a surface).
 
 Adapted from the neuromaps codebase
-(https://github.com/netneurolab/neuromaps/blob/main/neuromaps/points.py).
+(https://github.com/netneurolab/neuromaps/blob/ffcc2e0f657943ce00a1b6a968396f32250e495c/neuromaps/points.py).
 """
 
 from __future__ import annotations

--- a/src/neuromaps_prime/analysis/surfaces/points.py
+++ b/src/neuromaps_prime/analysis/surfaces/points.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import nibabel as nib
 import numpy as np
 from joblib import Parallel, delayed
 from scipy import ndimage
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import dijkstra
+
+from neuromaps_prime.analysis.images import load_gifti, relabel_gifti
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
 __all__ = ["get_surface_distance", "make_surf_graph"]
 
 # Default parcellations to ignore
-_PARC_IGNORE = frozenset(
+PARC_IGNORE = frozenset(
     {
         "unknown",
         "corpuscallosum",
@@ -394,78 +395,6 @@ def _geodesic_parcel_centroid(
     return vertices[inds[centroid_idx]]
 
 
-def _load_gifti(surface: str | Path) -> nib.GiftiImage:
-    """Load a GIFTI surface or label file.
-
-    Args:
-        surface: Path to a GIFTI file (``.gii``, ``.func.gii``, etc.).
-
-    Returns:
-        A ``nibabel.GiftiImage`` instance.
-
-    Raises:
-        ValueError: If the loaded image is not a GiftiImage.
-    """
-    img = nib.load(surface)
-    if not isinstance(img, nib.GiftiImage):
-        raise ValueError(f"Expected to load Gifti surface for: {surface}")
-    return img
-
-
-def _relabel_gifti(
-    parcellation: str | Path,
-    background: Iterable[str] | None = None,
-) -> nib.GiftiImage:
-    """Relabel a GIFTI parcellation so that label indices are consecutive.
-
-    Loads the parcellation file, zeroes out any background labels found in
-    the label table, then remaps the remaining indices to consecutive
-    integers starting at ``1``.  Returns a new ``GiftiImage`` with an
-    updated data array and label table.
-
-    Args:
-        parcellation: Path to a single GIFTI parcellation file.
-        background: Iterable of label names to treat as background and
-            zero out. Defaults to ``_PARC_IGNORE``.
-
-    Returns:
-        A ``GiftiImage`` instance with consecutive label indices and an
-        updated label table.
-    """
-    img = _load_gifti(parcellation)
-    data = img.agg_data().copy()
-    labels = img.labeltable.labels
-    lut = {v: k for k, v in img.labeltable.get_labels_as_dict().items()}
-
-    if background is None:
-        background = _PARC_IGNORE
-
-    # Zero out background labels
-    if len(labels) > 0:
-        for val in background:
-            idx = lut.get(val)
-            if idx is None:
-                continue
-            data[data == idx] = 0
-            labels = [f for f in labels if f.key != idx]
-
-    # Remap to consecutive indices starting at 1
-    data = np.unique(data, return_inverse=True)[-1]
-    new_labels = []
-    if len(labels) > 0:
-        for n, lab in enumerate(labels, start=1):
-            lab.key = n
-            new_labels.append(lab)
-
-    # Build updated GIFTI image
-    darr = nib.gifti.GiftiDataArray(
-        data, intent="NIFTI_INTENT_LABEL", datatype="NIFTI_TYPE_INT32"
-    )
-    labeltable = nib.gifti.GiftiLabelTable()
-    labeltable.labels = new_labels
-    return nib.GiftiImage(darrays=[darr], labeltable=labeltable)
-
-
 def _get_graph_distance(
     vertex: int,
     graph: csr_matrix,
@@ -515,7 +444,7 @@ def get_surface_distance(
     parcellation: str | Path | None = None,
     medial: str | Path | None = None,
     medial_labels: Iterable[str] | None = None,
-    drop: Iterable[str] = _PARC_IGNORE,
+    drop: Iterable[str] = PARC_IGNORE,
     n_proc: int = 1,
 ) -> np.ndarray:
     """Compute a geodesic distance matrix on a cortical surface.
@@ -538,7 +467,7 @@ def get_surface_distance(
             labels present in both *drop* and *medial_labels* are
             dropped.
         drop: Iterable of label names to exclude from the graph.
-            Defaults to ``_PARC_IGNORE``.
+            Defaults to ``PARC_IGNORE``.
         n_proc: Number of parallel workers for Dijkstra computation.
 
     Returns:
@@ -551,14 +480,14 @@ def get_surface_distance(
     if medial_labels is not None:
         drop = set(drop) & set(medial_labels)
 
-    vert, faces = _load_gifti(surface).agg_data()
+    vert, faces = load_gifti(surface).agg_data()
     n_vert = vert.shape[0]
     labels, mask = None, np.zeros(n_vert, dtype=bool)
 
     if medial is not None:
-        mask = _load_gifti(medial).agg_data().astype(bool)
+        mask = load_gifti(medial).agg_data().astype(bool)
     if parcellation is not None:
-        parcellation_img = _relabel_gifti(parcellation, background=drop)
+        parcellation_img = relabel_gifti(parcellation, background=drop)
         labels = parcellation_img.agg_data()
         mask[labels == 0] = True
 

--- a/src/neuromaps_prime/analysis/surfaces/points.py
+++ b/src/neuromaps_prime/analysis/surfaces/points.py
@@ -21,7 +21,7 @@ from scipy import ndimage
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import dijkstra
 
-from neuromaps_prime.analysis.images import load_gifti, relabel_gifti
+from neuromaps_prime.analysis.images import PARC_IGNORE, load_gifti, relabel_gifti
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -30,20 +30,6 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
 __all__ = ["get_surface_distance", "make_surf_graph"]
-
-# Default parcellations to ignore
-PARC_IGNORE = frozenset(
-    {
-        "unknown",
-        "corpuscallosum",
-        "Background+FreeSurfer_Defined_Medial_Wall",
-        "???",
-        "Unknown",
-        "Medial_wall",
-        "Medial wall",
-        "medial_wall",
-    }
-)
 
 
 def _get_edges(faces: ArrayLike) -> np.ndarray:

--- a/src/neuromaps_prime/analysis/surfaces/points.py
+++ b/src/neuromaps_prime/analysis/surfaces/points.py
@@ -273,7 +273,7 @@ def _get_shared_triangles(faces: ArrayLike) -> dict[tuple[int, int], np.ndarray]
         opposite[:, col] = tri[np.arange(n), opp_pos]
 
     triplets = np.empty((n, 2, 3), dtype=faces.dtype)
-    triplets[:, :, :2] = shared_edges
+    triplets[:, :, :2] = shared_edges[:, None, :]
     triplets[:, :, 2] = opposite
 
     return dict(zip(map(tuple, shared_edges), triplets, strict=True))

--- a/tests/unit/analysis/conftest.py
+++ b/tests/unit/analysis/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures for analysis tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+if TYPE_CHECKING:
+    from numpy.random import Generator
+
+
+@pytest.fixture(scope="module")
+def rng(seed: int = 12345) -> Generator:
+    """Deterministic random number generator."""
+    return np.random.default_rng(seed)

--- a/tests/unit/analysis/helpers.py
+++ b/tests/unit/analysis/helpers.py
@@ -1,0 +1,32 @@
+"""Helper functions for analysis unit tests."""
+
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+
+
+def _make_gifti_surface(coords: np.ndarray, faces: np.ndarray, path: Path) -> None:
+    """Write a GIFTI surface file."""
+    ptarr = nib.gifti.GiftiDataArray(
+        coords.astype(np.float32), intent="NIFTI_INTENT_POINTSET"
+    )
+    tris = nib.gifti.GiftiDataArray(faces, intent="NIFTI_INTENT_TRIANGLE")
+    nib.GiftiImage(darrays=[ptarr, tris]).to_filename(path)
+
+
+def _make_gifti_parc(
+    data: np.ndarray,
+    labels: list[tuple[int, str]],
+    path: Path,
+) -> None:
+    """Write a GIFTI parcellation file with label table."""
+    darr = nib.gifti.GiftiDataArray(
+        data.astype(np.int32), intent="NIFTI_INTENT_LABEL", datatype="NIFTI_TYPE_INT32"
+    )
+    lt = nib.gifti.GiftiLabelTable()
+    for key, name in labels:
+        lbl = nib.gifti.GiftiLabel(key=key)
+        lbl.label = name
+        lt.labels.append(lbl)
+    nib.GiftiImage(darrays=[darr], labeltable=lt).to_filename(path)

--- a/tests/unit/analysis/nulls/__init__.py
+++ b/tests/unit/analysis/nulls/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the nulls subpackage."""

--- a/tests/unit/analysis/nulls/conftest.py
+++ b/tests/unit/analysis/nulls/conftest.py
@@ -1,0 +1,236 @@
+"""Shared fixtures for nulls module tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+from tests.unit.analysis.helpers import _make_gifti_parc, _make_gifti_surface
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(scope="module")
+def simple_sphere(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Simple 4-vertex sphere-like surface."""
+    p = tmp_path_factory.mktemp("data") / "sphere.surf.gii"
+    coords = np.array(
+        [
+            [1.0, 1.0, 1.0],
+            [1.0, -1.0, -1.0],
+            [-1.0, 1.0, -1.0],
+            [-1.0, -1.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+    coords = coords / np.linalg.norm(coords, axis=1, keepdims=True)
+    faces = np.array([[0, 1, 2], [0, 2, 3], [0, 3, 1], [1, 3, 2]], dtype=np.int32)
+    _make_gifti_surface(coords, faces, p)
+    return p
+
+
+@pytest.fixture(scope="module")
+def two_hemi_surfaces(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Two hemisphere surfaces (left and right)."""
+    tmp_dir = tmp_path_factory.mktemp("data")
+    p_left = tmp_dir / "lh.sphere.surf.gii"
+    p_right = tmp_dir / "rh.sphere.surf.gii"
+
+    left_coords = np.array(
+        [[1.0, 0.5, 0.5], [0.5, 1.0, 0.5], [0.5, 0.5, 1.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    left_coords = left_coords / np.linalg.norm(left_coords, axis=1, keepdims=True)
+    _make_gifti_surface(
+        left_coords,
+        np.array([[0, 1, 2], [0, 2, 3], [0, 3, 1], [1, 3, 2]], dtype=np.int32),
+        p_left,
+    )
+
+    right_coords = np.array(
+        [[-1.0, 0.5, 0.5], [-0.5, 1.0, 0.5], [-0.5, 0.5, 1.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    right_coords = right_coords / np.linalg.norm(right_coords, axis=1, keepdims=True)
+    _make_gifti_surface(
+        right_coords,
+        np.array([[0, 1, 2], [0, 2, 3], [0, 3, 1], [1, 3, 2]], dtype=np.int32),
+        p_right,
+    )
+
+    return p_left, p_right
+
+
+@pytest.fixture(scope="module")
+def simple_parc(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Simple parcellation with 2 parcels + background."""
+    p = tmp_path_factory.mktemp("data") / "parc.label.gii"
+    _make_gifti_parc(
+        np.array([1, 1, 2, 2], dtype=np.int32), [(1, "Parcel_A"), (2, "Parcel_B")], p
+    )
+    return p
+
+
+@pytest.fixture(scope="module")
+def two_hemi_parcs(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Parcellations for both hemispheres with unique label values per hemisphere."""
+    tmp_dir = tmp_path_factory.mktemp("data")
+    p_left = tmp_dir / "lh.parc.label.gii"
+    p_right = tmp_dir / "rh.parc.label.gii"
+    _make_gifti_parc(
+        np.array([1, 1, 2, 2], dtype=np.int32),
+        [(1, "L_Parcel_A"), (2, "L_Parcel_B")],
+        p_left,
+    )
+    _make_gifti_parc(
+        np.array([3, 4, 4, 3], dtype=np.int32),
+        [(3, "R_Parcel_A"), (4, "R_Parcel_B")],
+        p_right,
+    )
+    return p_left, p_right
+
+
+@pytest.fixture(scope="module")
+def parc_with_unknown(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Parcellation with an 'unknown' label that should be dropped."""
+    p = tmp_path_factory.mktemp("data") / "parc_unknown.label.gii"
+    _make_gifti_parc(
+        np.array([1, 1, 99, 2], dtype=np.int32),
+        [(1, "Parcel_A"), (2, "Parcel_B"), (99, "unknown")],
+        p,
+    )
+    return p
+
+
+_ICOSA_COORDS = np.array(
+    [
+        [-1.0, 1.61803399, 0.0],
+        [1.0, 1.61803399, 0.0],
+        [-1.0, -1.61803399, 0.0],
+        [1.0, -1.61803399, 0.0],
+        [0.0, -1.0, 1.61803399],
+        [0.0, 1.0, 1.61803399],
+        [0.0, -1.0, -1.61803399],
+        [0.0, 1.0, -1.61803399],
+        [1.61803399, 0.0, -1.0],
+        [1.61803399, 0.0, 1.0],
+        [-1.61803399, 0.0, -1.0],
+        [-1.61803399, 0.0, 1.0],
+    ],
+    dtype=np.float32,
+)
+_ICOSA_COORDS = _ICOSA_COORDS / np.linalg.norm(_ICOSA_COORDS, axis=1, keepdims=True)
+_ICOSA_FACES = np.array(
+    [
+        [0, 11, 5],
+        [0, 5, 1],
+        [0, 1, 7],
+        [0, 7, 10],
+        [0, 10, 11],
+        [1, 5, 9],
+        [5, 11, 4],
+        [11, 10, 2],
+        [10, 7, 6],
+        [7, 1, 8],
+        [3, 9, 4],
+        [3, 4, 2],
+        [3, 2, 6],
+        [3, 6, 8],
+        [3, 8, 9],
+        [4, 9, 5],
+        [2, 4, 11],
+        [6, 2, 10],
+        [8, 6, 7],
+        [9, 8, 1],
+    ],
+    dtype=np.int32,
+)
+
+
+def _make_icosahedron(path: Path) -> None:
+    """Write a 12-vertex icosahedron surface to *path*."""
+    _make_gifti_surface(_ICOSA_COORDS, _ICOSA_FACES, path)
+
+
+@pytest.fixture(scope="module")
+def large_sphere(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """12-vertex icosahedron sphere surface."""
+    p = tmp_path_factory.mktemp("data") / "icosa.surf.gii"
+    _make_icosahedron(p)
+    return p
+
+
+@pytest.fixture(scope="module")
+def large_parc(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Parcellation with background (0) and 6 parcels over 12 vertices."""
+    p = tmp_path_factory.mktemp("data") / "icosa.parc.label.gii"
+    labels = np.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6], dtype=np.int32)
+    _make_gifti_parc(
+        labels,
+        [
+            (0, "background"),
+            (1, "P1"),
+            (2, "P2"),
+            (3, "P3"),
+            (4, "P4"),
+            (5, "P5"),
+            (6, "P6"),
+        ],
+        p,
+    )
+    return p
+
+
+@pytest.fixture(scope="module")
+def large_parc_with_unknown(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Icosahedron parcellation with background, 5 real parcels, and 'unknown'."""
+    p = tmp_path_factory.mktemp("data") / "icosa_unknown.parc.label.gii"
+    labels = np.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6], dtype=np.int32)
+    _make_gifti_parc(
+        labels,
+        [
+            (0, "background"),
+            (1, "P1"),
+            (2, "P2"),
+            (3, "P3"),
+            (4, "P4"),
+            (5, "P5"),
+            (6, "unknown"),
+        ],
+        p,
+    )
+    return p
+
+
+@pytest.fixture(scope="module")
+def two_hemi_large_surfaces(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[Path, Path]:
+    """Two icosahedron hemisphere surfaces."""
+    tmp_dir = tmp_path_factory.mktemp("data")
+    p_left = tmp_dir / "lh.icosa.surf.gii"
+    p_right = tmp_dir / "rh.icosa.surf.gii"
+    _make_icosahedron(p_left)
+    _make_icosahedron(p_right)
+    return p_left, p_right
+
+
+@pytest.fixture(scope="module")
+def two_hemi_large_parcs(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Two icosahedron parcellations with background + unique labels per hemi."""
+    tmp_dir = tmp_path_factory.mktemp("data")
+    p_left = tmp_dir / "lh.icosa.parc.label.gii"
+    p_right = tmp_dir / "rh.icosa.parc.label.gii"
+    _make_gifti_parc(
+        np.array([0, 1, 1, 2, 2, 3, 3, 0, 0, 0, 0, 0], dtype=np.int32),
+        [(0, "background"), (1, "L1"), (2, "L2"), (3, "L3")],
+        p_left,
+    )
+    _make_gifti_parc(
+        np.array([0, 0, 0, 0, 0, 0, 0, 4, 4, 5, 5, 6], dtype=np.int32),
+        [(0, "background"), (4, "R1"), (5, "R2"), (6, "R3")],
+        p_right,
+    )
+    return p_left, p_right

--- a/tests/unit/analysis/nulls/test_burt.py
+++ b/tests/unit/analysis/nulls/test_burt.py
@@ -1,0 +1,327 @@
+"""Unit tests for the Burt 2018 surrogate generation in burt.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from neuromaps_prime.analysis.surfaces.nulls.burt import (
+    SurrogateResult,
+    _make_weight_matrix,
+    batch_surrogates,
+    estimate_rho_d0,
+    make_surrogate,
+)
+
+if TYPE_CHECKING:
+    from numpy.random import Generator
+
+
+class TestMakeWeightMatrix:
+    """Tests for _make_weight_matrix()."""
+
+    def test_row_normalization(self) -> None:
+        """Verify each row sums to 1."""
+        dist = np.array([[0.0, 1.0, 2.0], [1.0, 0.0, 1.0], [2.0, 1.0, 0.0]])
+        w = _make_weight_matrix(dist, d0=1.0)
+        np.testing.assert_allclose(w.sum(axis=1), 1.0, rtol=1e-5)
+
+    def test_diagonal_is_zero(self) -> None:
+        """Verify diagonal is zeroed."""
+        dist = np.array([[0.0, 1.0, 2.0], [1.0, 0.0, 1.0], [2.0, 1.0, 0.0]])
+        w = _make_weight_matrix(dist, d0=1.0)
+        assert np.all(np.diag(w) == 0)
+
+    def test_symmetric_distance_produces_asymmetric_weights(self) -> None:
+        """Verify symmetric distance produce asymmetric weights due to normalization."""
+        dist = np.array([[0.0, 1.0, 2.0], [1.0, 0.0, 3.0], [2.0, 3.0, 0.0]])
+        w = _make_weight_matrix(dist, d0=1.0)
+        assert not np.allclose(w, w.T)
+
+    def test_small_d0_concentrates_weight(self) -> None:
+        """Verify small d0 concentrates weight on nearest neighbours."""
+        dist = np.array([[0.0, 1.0, 10.0], [1.0, 0.0, 1.0], [10.0, 1.0, 0.0]])
+        w_large = _make_weight_matrix(dist, d0=10.0)
+        w_small = _make_weight_matrix(dist, d0=0.1)
+        assert w_small[0, 2] < w_large[0, 2]
+
+    def test_off_diagonal_non_negative(self, rng: Generator) -> None:
+        """Verify off-diagonal weights are non-negative."""
+        dist = rng.random((5, 5))
+        np.fill_diagonal(dist, 0)
+        w = _make_weight_matrix(dist, d0=1.0)
+        assert np.all(a=w >= 0)
+
+
+class TestEstimateRhoD0:
+    """Tests for estimate_rho_d0()."""
+
+    @pytest.fixture
+    def valid_data_for_estimation(
+        self, rng: Generator
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Create valid distance matrix and positive data for estimation."""
+        coords = rng.random((20, 3))
+        dist = np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=-1)
+        data = np.exp(rng.random(20) * 0.5)
+        return dist, data
+
+    def test_returns_tuple_of_two_floats(
+        self, valid_data_for_estimation: tuple[np.ndarray, np.ndarray]
+    ) -> None:
+        """Verify output is a tuple of two floats."""
+        dist, data = valid_data_for_estimation
+        rho, d0 = estimate_rho_d0(dist, data)
+        assert isinstance(rho, float)
+        assert isinstance(d0, float)
+
+    def test_positive_outputs(
+        self, valid_data_for_estimation: tuple[np.ndarray, np.ndarray]
+    ) -> None:
+        """Verify outputs are finite."""
+        dist, data = valid_data_for_estimation
+        rho, d0 = estimate_rho_d0(dist, data)
+        assert np.isfinite(rho)
+        assert np.isfinite(d0)
+
+    def test_with_initial_guesses(
+        self, valid_data_for_estimation: tuple[np.ndarray, np.ndarray]
+    ) -> None:
+        """Verify initial guesses affect optimization."""
+        dist, data = valid_data_for_estimation
+        rho1, d01 = estimate_rho_d0(dist, data, rho=0.5, d0=1.0)
+        rho2, d02 = estimate_rho_d0(dist, data, rho=0.9, d0=5.0)
+        assert np.isfinite(rho1)
+        assert np.isfinite(d01)
+        assert np.isfinite(rho2)
+        assert np.isfinite(d02)
+
+    def test_small_dataset(self) -> None:
+        """Verify works with small dataset."""
+        dist = np.array([[0.0, 1.0], [1.0, 0.0]])
+        data = np.array([1.0, 2.0])
+        rho, d0 = estimate_rho_d0(dist, data)
+        assert np.isfinite(rho)
+        assert np.isfinite(d0)
+
+
+class TestMakeSurrogate:
+    """Tests for make_surrogate()."""
+
+    @pytest.fixture
+    def simple_distmat(self, rng: Generator) -> np.ndarray:
+        """Simple distance matrix for testing."""
+        coords = rng.random((20, 3))
+        return np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=-1)
+
+    @pytest.fixture
+    def simple_data(self, rng: Generator) -> np.ndarray:
+        """Simple positive data for testing."""
+        return np.abs(rng.random(20)) + 0.1
+
+    def test_returns_surrogate_result(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify output is SurrogateResult namedtuple."""
+        result = make_surrogate(simple_distmat, simple_data, seed=42)
+        assert isinstance(result, SurrogateResult)
+        assert hasattr(result, "surrogate")
+        assert hasattr(result, "order")
+        assert hasattr(result, "params")
+
+    def test_surrogate_same_length_as_input(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify surrogate has same length as input."""
+        result = make_surrogate(simple_distmat, simple_data, seed=42)
+        assert len(result.surrogate) == len(simple_data)
+
+    def test_surrogate_preserves_marginal_distribution(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify surrogate has same sorted values as input."""
+        result = make_surrogate(simple_distmat, simple_data, seed=42)
+        np.testing.assert_array_equal(np.sort(result.surrogate), np.sort(simple_data))
+
+    def test_with_return_order(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify order is returned when requested."""
+        result = make_surrogate(simple_distmat, simple_data, seed=42, return_order=True)
+        assert result.order is not None
+        assert len(result.order) == len(simple_data)
+
+    def test_with_return_params(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify params are returned when requested."""
+        result = make_surrogate(
+            simple_distmat, simple_data, seed=42, return_params=True
+        )
+        assert result.params is not None
+        rho, d0 = result.params
+        assert isinstance(rho, float)
+        assert isinstance(d0, float)
+
+    def test_with_precomputed_params(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify precomputed params skip estimation."""
+        result1 = make_surrogate(simple_distmat, simple_data, rho=0.5, d0=2.0, seed=42)
+        result2 = make_surrogate(simple_distmat, simple_data, rho=0.5, d0=2.0, seed=42)
+        np.testing.assert_array_almost_equal(result1.surrogate, result2.surrogate)
+
+    def test_different_seeds_produce_different_surrogates(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify different seeds produce different surrogates."""
+        result1 = make_surrogate(simple_distmat, simple_data, seed=42)
+        result2 = make_surrogate(simple_distmat, simple_data, seed=123)
+        assert not np.allclose(result1.surrogate, result2.surrogate)
+
+    def test_reproducible_with_same_seed(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify same seed produces same surrogate."""
+        result1 = make_surrogate(simple_distmat, simple_data, seed=42)
+        result2 = make_surrogate(simple_distmat, simple_data, seed=42)
+        np.testing.assert_array_almost_equal(result1.surrogate, result2.surrogate)
+
+
+class TestBatchSurrogates:
+    """Tests for batch_surrogates()."""
+
+    @pytest.fixture
+    def simple_distmat(self, rng: Generator) -> np.ndarray:
+        """Simple distance matrix for testing."""
+        coords = rng.random((20, 3))
+        return np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=-1)
+
+    @pytest.fixture
+    def simple_data(self, rng: Generator) -> np.ndarray:
+        """Simple positive data for testing."""
+        return np.abs(rng.random(20)) + 0.1
+
+    def test_output_shape(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify output shape is (n, n_surr)."""
+        result = batch_surrogates(simple_distmat, simple_data, n_surr=10, seed=42)
+        assert result.shape == (20, 10)
+
+    def test_each_column_preserves_marginal(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify each surrogate column preserves marginal distribution."""
+        result = batch_surrogates(simple_distmat, simple_data, n_surr=5, seed=42)
+        for k in range(5):
+            np.testing.assert_array_equal(np.sort(result[:, k]), np.sort(simple_data))
+
+    def test_different_columns_are_different(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify different columns are different surrogates."""
+        result = batch_surrogates(simple_distmat, simple_data, n_surr=5, seed=42)
+        for i in range(5):
+            for j in range(i + 1, 5):
+                assert not np.allclose(result[:, i], result[:, j])
+
+    def test_n_jobs_parallel(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify n_jobs > 1 produces valid results."""
+        result_single = batch_surrogates(
+            simple_distmat, simple_data, n_surr=5, seed=42, n_jobs=1
+        )
+        result_parallel = batch_surrogates(
+            simple_distmat, simple_data, n_surr=5, seed=42, n_jobs=2
+        )
+        assert result_single.shape == result_parallel.shape
+        for k in range(5):
+            np.testing.assert_array_equal(
+                np.sort(result_parallel[:, k]), np.sort(simple_data)
+            )
+
+    def test_zero_n_surr_raises(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify n_surr=0 raises ValueError."""
+        with pytest.raises(ValueError, match="n_surr must be positive"):
+            batch_surrogates(simple_distmat, simple_data, n_surr=0, seed=42)
+
+    def test_negative_n_surr_raises(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify negative n_surr raises ValueError."""
+        with pytest.raises(ValueError, match="n_surr must be positive"):
+            batch_surrogates(simple_distmat, simple_data, n_surr=-1, seed=42)
+
+    def test_sparse_matrix_handling(
+        self, simple_data: np.ndarray, rng: Generator
+    ) -> None:
+        """Verify sparse matrix path works for sparse-like inputs."""
+        sparse_like = rng.random((20, 20)) * 0.01
+        np.fill_diagonal(sparse_like, 0)
+        result = batch_surrogates(sparse_like, simple_data, n_surr=3, seed=42)
+        assert result.shape == (20, 3)
+
+    def test_reproducible_with_same_seed(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify same seed produces same batch."""
+        result1 = batch_surrogates(simple_distmat, simple_data, n_surr=5, seed=42)
+        result2 = batch_surrogates(simple_distmat, simple_data, n_surr=5, seed=42)
+        np.testing.assert_array_almost_equal(result1, result2)
+
+    def test_with_precomputed_params(
+        self, simple_distmat: np.ndarray, simple_data: np.ndarray
+    ) -> None:
+        """Verify precomputed params skip estimation."""
+        result1 = batch_surrogates(
+            simple_distmat, simple_data, rho=0.5, d0=2.0, n_surr=3, seed=42
+        )
+        result2 = batch_surrogates(
+            simple_distmat, simple_data, rho=0.5, d0=2.0, n_surr=3, seed=42
+        )
+        np.testing.assert_array_almost_equal(result1, result2)
+
+
+class TestEdgeCases:
+    """Edge case tests for burt.py functions."""
+
+    def test_very_small_data(self, rng: Generator) -> None:
+        """Verify handling of small but valid datasets."""
+        coords = rng.standard_normal((5, 3))
+        dist = np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=-1)
+        data = np.abs(rng.standard_normal(5)) + 0.1
+        result = make_surrogate(dist, data, seed=42)
+        assert len(result.surrogate) == 5
+        assert np.isfinite(result.surrogate).all()
+
+    def test_data_with_outliers(self, rng: Generator) -> None:
+        """Verify handling of data with outliers."""
+        coords = rng.random((20, 3))
+        dist = np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=-1)
+        data = np.abs(rng.random(20)) + 0.1
+        data[0] = 100.0
+        result = make_surrogate(dist, data, seed=42)
+        np.testing.assert_array_equal(np.sort(result.surrogate), np.sort(data))
+
+    def test_very_high_autocorrelation(self) -> None:
+        """Verify handling of highly autocorrelated data."""
+        coords = np.linspace(0, 1, 20)
+        dist = np.abs(coords[:, None] - coords[None, :])
+        data = np.sin(coords * 10) + 2
+        result = make_surrogate(dist, data, seed=42)
+        assert len(result.surrogate) == 20
+
+    def test_weight_matrix_with_identical_distances(self) -> None:
+        """Verify weight matrix with uniform distances."""
+        dist = np.ones((5, 5))
+        np.fill_diagonal(dist, 0)
+        w = _make_weight_matrix(dist, d0=1.0)
+        for i in range(5):
+            row_vals = w[i, :]
+            assert np.allclose(row_vals[row_vals > 0], row_vals[row_vals > 0][0])

--- a/tests/unit/analysis/nulls/test_nulls.py
+++ b/tests/unit/analysis/nulls/test_nulls.py
@@ -1,0 +1,543 @@
+"""Unit tests for the null model convenience wrappers in nulls.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import nibabel as nib
+import numpy as np
+import pytest
+
+from neuromaps_prime.analysis.images import PARC_IGNORE
+from neuromaps_prime.analysis.surfaces.nulls.nulls import (
+    _generate_spins,
+    _resolve_data,
+    _spin_permute,
+    alexander_bloch,
+    baum,
+    burt2018,
+    cornblath,
+    hungarian,
+    vasa,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from numpy.random import Generator
+
+
+class TestResolveData:
+    """Tests for _resolve_data()."""
+
+    def test_array_input(self) -> None:
+        """Verify array input is flattened."""
+        data = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = _resolve_data(data, {})
+        assert result.shape == (4,)
+        np.testing.assert_array_equal(result, [1, 2, 3, 4])
+
+    def test_gifti_file_input(self, tmp_path: Path) -> None:
+        """Verify GIFTI file is loaded and flattened."""
+        data_arr = nib.gifti.GiftiDataArray(
+            np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32),
+            intent="NIFTI_INTENT_NONE",
+        )
+        img = nib.GiftiImage(darrays=[data_arr])
+        gii_path = tmp_path / "data.func.gii"
+        img.to_filename(str(gii_path))
+        result = _resolve_data(gii_path, {})
+        assert result.shape == (4,)
+        np.testing.assert_array_almost_equal(result, [1, 2, 3, 4])
+
+    def test_tuple_input(self, tmp_path: Path) -> None:
+        """Verify tuple of GIFTI files are stacked."""
+        left_arr = nib.gifti.GiftiDataArray(
+            np.array([1.0, 2.0], dtype=np.float32), intent="NIFTI_INTENT_NONE"
+        )
+        left_path = tmp_path / "lh.func.gii"
+        nib.GiftiImage(darrays=[left_arr]).to_filename(str(left_path))
+        right_arr = nib.gifti.GiftiDataArray(
+            np.array([3.0, 4.0, 5.0], dtype=np.float32), intent="NIFTI_INTENT_NONE"
+        )
+        right_path = tmp_path / "rh.func.gii"
+        nib.GiftiImage(darrays=[right_arr]).to_filename(str(right_path))
+        result = _resolve_data((left_path, right_path), {})
+        assert result.shape == (5,)
+        np.testing.assert_array_almost_equal(result, [1, 2, 3, 4, 5])
+
+    def test_gifti_image_input(self) -> None:
+        """Verify GiftiImage object is loaded directly."""
+        data_arr = nib.gifti.GiftiDataArray(
+            np.array([10.0, 20.0, 30.0], dtype=np.float32), intent="NIFTI_INTENT_NONE"
+        )
+        result = _resolve_data(nib.GiftiImage(darrays=[data_arr]), {})
+        assert result.shape == (3,)
+        np.testing.assert_array_almost_equal(result, [10, 20, 30])
+
+
+class TestSpinPermute:
+    """Tests for _spin_permute() pipeline."""
+
+    def test_returns_spin_matrix_when_data_none(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify data=None returns spin permutation matrix."""
+        result = _spin_permute(
+            None,
+            simple_sphere,
+            parcellation=simple_parc,
+            n_perm=5,
+            seed=42,
+            spins=None,
+            spin_method="original",
+            method="surface",
+            drop=PARC_IGNORE,
+        )
+        assert result.shape == (2, 5)
+        assert result.dtype == np.int32
+
+    def test_vertex_level_permutation(self, simple_sphere: Path) -> None:
+        """Verify vertex-level spin permutation works."""
+        result = _spin_permute(
+            np.array([1.0, 2.0, 3.0, 4.0]),
+            simple_sphere,
+            parcellation=None,
+            n_perm=3,
+            seed=123,
+            spins=None,
+            spin_method="original",
+            method="surface",
+            drop=PARC_IGNORE,
+        )
+        assert result.shape == (4, 3)
+
+    def test_mismatched_data_length_raises(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify ValueError when data length doesn't match parcel count."""
+        with pytest.raises(ValueError, match="does not match"):
+            _spin_permute(
+                np.array([1.0, 2.0, 3.0]),
+                simple_sphere,
+                parcellation=simple_parc,
+                n_perm=3,
+                seed=42,
+                spins=None,
+                spin_method="original",
+                method="surface",
+                drop=PARC_IGNORE,
+            )
+
+    def test_precomputed_spins_ignores_surface(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify precomputed spins bypass surface loading."""
+        spins = np.array([[0, 1, 0], [1, 0, 1]], dtype=np.int32)
+        data = np.array([10.0, 20.0])
+        result = _spin_permute(
+            data,
+            simple_sphere,
+            parcellation=simple_parc,
+            n_perm=3,
+            seed=42,
+            spins=spins,
+            spin_method="original",
+            method="surface",
+            drop=PARC_IGNORE,
+        )
+        np.testing.assert_array_equal(result, data[spins])
+
+
+class TestAlexanderBloch:
+    """Tests for alexander_bloch()."""
+
+    def test_vertex_level_output_shape(self, simple_sphere: Path) -> None:
+        """Verify vertex-level output shape."""
+        result = alexander_bloch(
+            np.array([1.0, 2.0, 3.0, 4.0]), simple_sphere, n_perm=10, seed=42
+        )
+        assert result.shape == (4, 10)
+
+    def test_parcellated_output_shape(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify parcellated output shape."""
+        result = alexander_bloch(
+            np.array([10.0, 20.0]),
+            simple_sphere,
+            parcellation=simple_parc,
+            n_perm=10,
+            seed=42,
+        )
+        assert result.shape == (2, 10)
+
+    def test_returns_spin_matrix_when_data_none(self, simple_sphere: Path) -> None:
+        """Verify data=None returns spin matrix."""
+        result = alexander_bloch(None, simple_sphere, n_perm=7, seed=99)
+        assert result.shape == (4, 7)
+
+    def test_dual_hemisphere_vertex_level(
+        self, two_hemi_surfaces: tuple[Path, Path]
+    ) -> None:
+        """Verify dual-hemisphere vertex-level works."""
+        result = alexander_bloch(
+            np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+            two_hemi_surfaces,
+            n_perm=5,
+            seed=42,
+        )
+        assert result.shape == (8, 5)
+
+    def test_dual_hemisphere_parcellated(
+        self, two_hemi_surfaces: tuple[Path, Path], two_hemi_parcs: tuple[Path, Path]
+    ) -> None:
+        """Verify dual-hemisphere parcellated works."""
+        result = alexander_bloch(
+            np.array([10.0, 20.0, 30.0, 40.0]),
+            two_hemi_surfaces,
+            parcellation=two_hemi_parcs,
+            n_perm=5,
+            seed=42,
+        )
+        assert result.shape == (4, 5)
+
+    def test_drop_unknown_labels(
+        self, simple_sphere: Path, parc_with_unknown: Path
+    ) -> None:
+        """Verify 'unknown' label is dropped from parcellation."""
+        result = alexander_bloch(
+            np.array([10.0, 20.0]),
+            simple_sphere,
+            parcellation=parc_with_unknown,
+            n_perm=5,
+            seed=42,
+        )
+        assert result.shape == (2, 5)
+
+
+class TestVasa:
+    """Tests for vasa()."""
+
+    def test_requires_parcellation(self, simple_sphere: Path) -> None:
+        """Verify vasa requires parcellation argument."""
+        with pytest.raises(TypeError, match="parcellation"):
+            vasa(np.array([1.0, 2.0, 3.0, 4.0]), simple_sphere, n_perm=5, seed=42)  # type: ignore
+
+    def test_output_shape_with_parcel(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify output shape with parcellation."""
+        result = vasa(
+            np.array([10.0, 20.0]),
+            simple_sphere,
+            parcellation=simple_parc,
+            n_perm=5,
+            seed=42,
+        )
+        assert result.shape == (2, 5)
+
+
+class TestHungarian:
+    """Tests for hungarian()."""
+
+    def test_requires_parcellation(self, simple_sphere: Path) -> None:
+        """Verify hungarian requires parcellation argument."""
+        with pytest.raises(TypeError, match="parcellation"):
+            hungarian(np.array([1.0, 2.0, 3.0, 4.0]), simple_sphere, n_perm=5, seed=42)  # type: ignore
+
+    def test_output_shape_with_parcel(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify output shape with parcellation."""
+        result = hungarian(
+            np.array([10.0, 20.0]),
+            simple_sphere,
+            parcellation=simple_parc,
+            n_perm=5,
+            seed=42,
+        )
+        assert result.shape == (2, 5)
+
+
+class TestBaum:
+    """Tests for baum()."""
+
+    def test_requires_parcellation(self, simple_sphere: Path) -> None:
+        """Verify baum requires parcellation argument."""
+        with pytest.raises(TypeError, match="parcellation"):
+            baum(np.array([1.0, 2.0, 3.0, 4.0]), simple_sphere, n_perm=5, seed=42)  # type: ignore
+
+    def test_output_shape_with_parcel(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify output shape with parcellation."""
+        result = baum(
+            np.array([10.0, 20.0]),
+            simple_sphere,
+            parcellation=simple_parc,
+            n_perm=5,
+            seed=42,
+        )
+        assert result.shape == (2, 5)
+
+    def test_returns_spin_matrix_when_data_none(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify data=None returns spin matrix."""
+        result = baum(None, simple_sphere, parcellation=simple_parc, n_perm=5, seed=42)
+        assert result.shape == (2, 5)
+
+    def test_nan_for_unmatched_parcels(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify unmatched parcels get NaN in output."""
+        result = baum(
+            np.array([10.0, 20.0]),
+            simple_sphere,
+            parcellation=simple_parc,
+            n_perm=3,
+            seed=999,
+        )
+        assert result.shape == (2, 3)
+        assert np.isfinite(result).any()
+
+    def test_mismatched_data_length_raises(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify ValueError when data length doesn't match parcel count."""
+        with pytest.raises(ValueError, match="does not match"):
+            baum(
+                np.array([1.0, 2.0, 3.0]),
+                simple_sphere,
+                parcellation=simple_parc,
+                n_perm=5,
+                seed=42,
+            )
+
+
+class TestCornblath:
+    """Tests for cornblath()."""
+
+    def test_requires_parcellation(self, simple_sphere: Path) -> None:
+        """Verify cornblath requires parcellation argument."""
+        with pytest.raises(TypeError, match="parcellation"):
+            cornblath(np.array([1.0, 2.0, 3.0, 4.0]), simple_sphere, n_perm=5, seed=42)  # type: ignore
+
+    def test_output_shape_with_parcel(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify output shape with parcellation."""
+        result = cornblath(
+            np.array([10.0, 20.0]),
+            simple_sphere,
+            parcellation=simple_parc,
+            n_perm=5,
+            seed=42,
+        )
+        assert result.shape == (2, 5)
+        assert np.isfinite(result).all()
+
+
+class TestBurt2018:
+    """Tests for burt2018()."""
+
+    def test_vertex_level_output_shape(self, simple_sphere: Path) -> None:
+        """Verify vertex-level output shape."""
+        result = burt2018(
+            np.array([1.0, 2.0, 3.0, 4.0]), simple_sphere, n_perm=5, seed=42, n_proc=1
+        )
+        assert result.shape == (4, 5)
+
+    def test_parcellated_output_shape(
+        self, large_sphere: Path, large_parc: Path
+    ) -> None:
+        """Verify parcellated output shape."""
+        result = burt2018(
+            np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0]),
+            large_sphere,
+            parcellation=large_parc,
+            n_perm=5,
+            seed=42,
+            n_proc=1,
+        )
+        assert result.shape == (6, 5)
+        assert np.isfinite(result).all()
+
+    def test_dual_hemisphere_vertex_level(
+        self, two_hemi_surfaces: tuple[Path, Path]
+    ) -> None:
+        """Verify dual-hemisphere vertex-level works."""
+        result = burt2018(
+            np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+            two_hemi_surfaces,
+            n_perm=5,
+            seed=42,
+            n_proc=1,
+        )
+        assert result.shape == (8, 5)
+
+    def test_dual_hemisphere_parcellated(
+        self,
+        two_hemi_large_surfaces: tuple[Path, Path],
+        two_hemi_large_parcs: tuple[Path, Path],
+    ) -> None:
+        """Verify dual-hemisphere parcellated works."""
+        result = burt2018(
+            np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0]),
+            two_hemi_large_surfaces,
+            parcellation=two_hemi_large_parcs,
+            n_perm=5,
+            seed=42,
+            n_proc=1,
+        )
+        assert result.shape == (6, 5)
+        assert np.isfinite(result).all()
+
+    def test_with_precomputed_distmat(
+        self, simple_sphere: Path, rng: Generator
+    ) -> None:
+        """Verify precomputed distance matrix is used."""
+        data = np.array([1.0, 2.0, 3.0, 4.0])
+        distmat = rng.random((4, 4))
+        distmat = distmat + distmat.T
+        result = burt2018(
+            data, simple_sphere, n_perm=3, seed=42, distmat=distmat, n_proc=1
+        )
+        assert result.shape == (4, 3)
+
+    def test_with_tuple_distmat(
+        self, two_hemi_surfaces: tuple[Path, Path], rng: Generator
+    ) -> None:
+        """Verify tuple of distance matrices works for dual hemi."""
+        data = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        dist_left = rng.random((4, 4))
+        dist_right = np.random.default_rng(12346).random((4, 4))
+        dist_left = dist_left + dist_left.T
+        dist_right = dist_right + dist_right.T
+        result = burt2018(
+            data,
+            two_hemi_surfaces,
+            n_perm=3,
+            seed=42,
+            distmat=(dist_left, dist_right),
+            n_proc=1,
+        )
+        assert result.shape == (8, 3)
+
+    def test_mismatched_data_length_raises(
+        self, large_sphere: Path, large_parc: Path
+    ) -> None:
+        """Verify ValueError when data length doesn't match parcel count."""
+        data = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+        with pytest.raises(IndexError, match="out of bounds"):
+            burt2018(
+                data, large_sphere, parcellation=large_parc, n_perm=3, seed=42, n_proc=1
+            )
+
+    def test_handles_negative_data(self, simple_sphere: Path) -> None:
+        """Verify negative data is handled via shift."""
+        result = burt2018(
+            np.array([-5.0, -3.0, 0.0, 2.0]), simple_sphere, n_perm=3, seed=42, n_proc=1
+        )
+        assert result.shape == (4, 3)
+        assert np.isfinite(result).all()
+
+    def test_drop_unknown_labels(
+        self, large_sphere: Path, large_parc_with_unknown: Path
+    ) -> None:
+        """Verify 'unknown' label handling in burt2018."""
+        result = burt2018(
+            np.array([10.0, 20.0, 30.0, 40.0, 50.0]),
+            large_sphere,
+            parcellation=large_parc_with_unknown,
+            n_perm=5,
+            seed=42,
+            n_proc=1,
+        )
+        assert result.shape == (5, 5)
+        assert np.isfinite(result).all()
+
+
+class TestGenerateSpins:
+    """Tests for _generate_spins() helper."""
+
+    def test_single_hemisphere(self, simple_sphere: Path, simple_parc: Path) -> None:
+        """Verify single hemisphere spin generation."""
+        spin_matrix, n_elements = _generate_spins(
+            simple_sphere,
+            simple_parc,
+            n_perm=5,
+            seed=42,
+            centroid_method="surface",
+            spin_method="original",
+            drop=PARC_IGNORE,
+            gifti_cache={},
+        )
+        assert spin_matrix.shape == (2, 5)
+        assert n_elements == 2
+
+    def test_dual_hemisphere(self, two_hemi_surfaces: tuple[Path, Path]) -> None:
+        """Verify dual hemisphere spin generation."""
+        spin_matrix, n_elements = _generate_spins(
+            two_hemi_surfaces,
+            None,
+            n_perm=5,
+            seed=42,
+            centroid_method="surface",
+            spin_method="original",
+            drop=PARC_IGNORE,
+            gifti_cache={},
+        )
+        assert spin_matrix.shape == (8, 5)
+        assert n_elements == 8
+
+    def test_mismatched_surface_parcellation_count_raises(
+        self, two_hemi_surfaces: tuple[Path, Path], simple_parc: Path
+    ) -> None:
+        """Verify ValueError when surface and parcellation counts mismatch."""
+        with pytest.raises(ValueError, match="Number of surface and parcellation"):
+            _generate_spins(
+                two_hemi_surfaces,
+                simple_parc,
+                n_perm=5,
+                seed=42,
+                centroid_method="surface",
+                spin_method="original",
+                drop=PARC_IGNORE,
+                gifti_cache={},
+            )
+
+    def test_centroid_method_average(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify average centroid method works."""
+        spin_matrix, n_elements = _generate_spins(
+            simple_sphere,
+            simple_parc,
+            n_perm=3,
+            seed=42,
+            centroid_method="average",
+            spin_method="original",
+            drop=PARC_IGNORE,
+            gifti_cache={},
+        )
+        assert spin_matrix.shape == (2, 3)
+        assert n_elements == 2
+
+    def test_centroid_method_geodesic(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify geodesic centroid method works."""
+        spin_matrix, n_elements = _generate_spins(
+            simple_sphere,
+            simple_parc,
+            n_perm=3,
+            seed=42,
+            centroid_method="geodesic",
+            spin_method="original",
+            drop=PARC_IGNORE,
+            gifti_cache={},
+        )
+        assert spin_matrix.shape == (2, 3)
+        assert n_elements == 2

--- a/tests/unit/analysis/nulls/test_spins.py
+++ b/tests/unit/analysis/nulls/test_spins.py
@@ -1,0 +1,491 @@
+"""Unit tests for the spin permutation utilities in spins.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import nibabel as nib
+import numpy as np
+import pytest
+from tests.unit.analysis.helpers import _make_gifti_parc
+
+from neuromaps_prime.analysis.surfaces.nulls.spins import (
+    Rotation,
+    SpinResult,
+    _assign_coordinates,
+    _gen_rotation,
+    _get_parcel_centroids,
+    _max_overlap,
+    _to_hemisphere_list,
+    _validate_spin_inputs,
+    gen_spin_samples,
+    get_parcel_centroids,
+    load_spins,
+    parcels_to_vertices,
+    spin_data,
+    spin_parcels,
+    vertices_to_parcels,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from numpy.random import Generator
+
+
+class TestToHemisphereList:
+    """Tests for _to_hemisphere_list()."""
+
+    def test_single_path(self) -> None:
+        """Verify single path becomes single-element list."""
+        result = _to_hemisphere_list("/path/to/file.surf.gii")
+        assert result == ["/path/to/file.surf.gii"]
+
+    def test_tuple_paths(self) -> None:
+        """Verify tuple becomes two-element list."""
+        result = _to_hemisphere_list(("/path/lh.surf.gii", "/path/rh.surf.gii"))
+        assert result == ["/path/lh.surf.gii", "/path/rh.surf.gii"]
+
+
+class TestGenRotation:
+    """Tests for _gen_rotation()."""
+
+    def test_returns_rotation_namedtuple(self) -> None:
+        """Verify output is a Rotation namedtuple."""
+        rot = _gen_rotation(seed=42)
+        assert isinstance(rot, Rotation)
+        assert hasattr(rot, "left")
+        assert hasattr(rot, "right")
+
+    def test_both_matrices_are_orthogonal(self) -> None:
+        """Verify rotation matrices are orthogonal (R @ R.T = I)."""
+        rot = _gen_rotation(seed=42)
+        np.testing.assert_allclose(rot.left @ rot.left.T, np.eye(3), atol=1e-6)
+        np.testing.assert_allclose(rot.right @ rot.right.T, np.eye(3), atol=1e-6)
+
+    def test_both_matrices_have_det_one(self) -> None:
+        """Verify rotation matrices have determinant +1."""
+        rot = _gen_rotation(seed=42)
+        assert np.isclose(np.linalg.det(rot.left), 1.0)
+        assert np.isclose(np.linalg.det(rot.right), 1.0)
+
+    def test_right_is_reflected_left(self) -> None:
+        """Verify right hemisphere rotation is reflected left."""
+        rot = _gen_rotation(seed=42)
+        reflect_x = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        np.testing.assert_allclose(rot.right, reflect_x @ rot.left @ reflect_x)
+
+    def test_different_seeds_produce_different_rotations(self) -> None:
+        """Verify different seeds produce different rotations."""
+        rot1 = _gen_rotation(seed=42)
+        rot2 = _gen_rotation(seed=123)
+        assert not np.allclose(rot1.left, rot2.left)
+
+
+class TestValidateSpinInputs:
+    """Tests for _validate_spin_inputs()."""
+
+    def test_valid_inputs_pass(self, rng: Generator) -> None:
+        """Verify valid inputs don't raise."""
+        coords = rng.random((10, 3))
+        hemi_id = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], dtype=np.int8)
+        _validate_spin_inputs(coords, hemi_id)
+
+    def test_bad_coords_shape_raises(self, rng: Generator) -> None:
+        """Verify wrong coords shape raises ValueError."""
+        coords = rng.random((10, 4))
+        hemi_id = np.zeros(10, dtype=np.int8)
+        with pytest.raises(ValueError, match="must be of shape"):
+            _validate_spin_inputs(coords, hemi_id)
+
+    def test_bad_hemi_id_ndim_raises(self, rng: Generator) -> None:
+        """Verify 2D hemi_id raises ValueError."""
+        coords = rng.random((10, 3))
+        hemi_id = np.zeros((10, 1), dtype=np.int8)
+        with pytest.raises(ValueError, match="must be one-dimensional"):
+            _validate_spin_inputs(coords, hemi_id)
+
+    def test_mismatched_lengths_raises(self, rng: Generator) -> None:
+        """Verify mismatched lengths raises ValueError."""
+        coords = rng.random((10, 3))
+        hemi_id = np.zeros(5, dtype=np.int8)
+        with pytest.raises(ValueError, match="same length"):
+            _validate_spin_inputs(coords, hemi_id)
+
+    def test_invalid_hemi_values_raises(self, rng: Generator) -> None:
+        """Verify hemi_id values other than 0/1 raise ValueError."""
+        coords = rng.random((10, 3))
+        hemi_id = np.array([0, 0, 1, 1, 2, 2, 0, 1, 0, 1], dtype=np.int8)
+        with pytest.raises(ValueError, match=r"\{0, 1\}"):
+            _validate_spin_inputs(coords, hemi_id)
+
+
+class TestAssignCoordinates:
+    """Tests for _assign_coordinates()."""
+
+    def test_original_method_kdtree(self) -> None:
+        """Verify original method uses KDTree nearest-neighbour."""
+        coor = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+        rotated = np.array([[0.1, 0.1, 0.0], [0.9, -0.1, 0.0]])
+        col, dist = _assign_coordinates(coor, rotated, "original")
+        assert col.shape == (2,)
+        assert dist.shape == (2,)
+        assert np.all(col >= 0)
+        assert np.all(col < 2)
+
+    def test_vasa_method_greedy(self) -> None:
+        """Verify vasa method uses greedy assignment."""
+        coor = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        rotated = np.array([[0.1, 0.1, 0.0], [0.9, -0.1, 0.0], [0.0, 0.9, 0.1]])
+        col, costs = _assign_coordinates(coor, rotated, "vasa")
+        assert col.shape == (3,)
+        assert costs.shape == (3,)
+        assert len(np.unique(col)) == 3
+        assert np.all(costs >= 0)
+
+    def test_hungarian_method_optimal(self) -> None:
+        """Verify hungarian method uses optimal assignment."""
+        coor = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        rotated = np.array([[0.1, 0.1, 0.0], [0.9, -0.1, 0.0], [0.0, 0.9, 0.1]])
+        col, costs = _assign_coordinates(coor, rotated, "hungarian")
+        assert col.shape == (3,)
+        assert costs.shape == (3,)
+        assert len(np.unique(col)) == 3
+        assert np.all(costs >= 0)
+
+    def test_unknown_method_raises(self) -> None:
+        """Verify unknown method raises ValueError."""
+        coor = np.array([[0.0, 0.0, 0.0]])
+        rotated = np.array([[0.1, 0.1, 0.0]])
+        with pytest.raises(ValueError, match="Unknown method"):
+            _assign_coordinates(coor, rotated, "unknown_method")  # type: ignore
+
+
+class TestGenSpinSamples:
+    """Tests for gen_spin_samples()."""
+
+    def test_output_shapes(self, rng: Generator) -> None:
+        """Verify output is SpinResult with correct shapes."""
+        coords = rng.random((10, 3))
+        hemi_id = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], dtype=np.int8)
+        result = gen_spin_samples(coords, hemi_id, n_rotate=5, seed=42)
+        assert isinstance(result, SpinResult)
+        assert result.spin.shape == (10, 5)
+        assert result.cost is None
+
+    def test_with_return_cost(self, rng: Generator) -> None:
+        """Verify return_cost=True returns cost matrix."""
+        coords = rng.random((10, 3))
+        hemi_id = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], dtype=np.int8)
+        result = gen_spin_samples(
+            coords, hemi_id, n_rotate=5, seed=42, return_cost=True
+        )
+        assert result.cost is not None
+        assert result.cost.shape == (10, 5)
+
+    def test_spins_are_permutations(self, rng: Generator) -> None:
+        """Verify each spin column has all indices exactly once."""
+        coords = rng.random((8, 3))
+        hemi_id = np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.int8)
+        result = gen_spin_samples(coords, hemi_id, n_rotate=3, seed=42)
+        for k in range(3):
+            assert len(result.spin[:, k]) == 8
+
+    def test_vasa_method(self, rng: Generator) -> None:
+        """Verify vasa spin method works."""
+        coords = rng.random((8, 3))
+        hemi_id = np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.int8)
+        result = gen_spin_samples(coords, hemi_id, n_rotate=3, method="vasa", seed=42)
+        assert result.spin.shape == (8, 3)
+
+    def test_hungarian_method(self, rng: Generator) -> None:
+        """Verify hungarian spin method works."""
+        coords = rng.random((8, 3))
+        hemi_id = np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.int8)
+        result = gen_spin_samples(
+            coords, hemi_id, n_rotate=3, method="hungarian", seed=42
+        )
+        assert result.spin.shape == (8, 3)
+
+    def test_check_duplicates_removes_identity(self, rng: Generator) -> None:
+        """Verify check_duplicates=True removes identity permutation."""
+        coords = rng.random((8, 3))
+        hemi_id = np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.int8)
+        result = gen_spin_samples(
+            coords, hemi_id, n_rotate=5, seed=42, check_duplicates=True
+        )
+        identity = np.arange(8, dtype=np.int32)
+        for k in range(5):
+            assert not np.array_equal(result.spin[:, k], identity)
+
+    def test_unknown_method_raises(self, rng: Generator) -> None:
+        """Verify unknown method raises ValueError."""
+        coords = rng.random((8, 3))
+        hemi_id = np.zeros(8, dtype=np.int8)
+        with pytest.raises(ValueError, match="invalid"):
+            gen_spin_samples(coords, hemi_id, method="unknown")  # type: ignore
+
+
+class TestMaxOverlap:
+    """Tests for _max_overlap()."""
+
+    def test_returns_most_common_positive_label(self) -> None:
+        """Verify most common positive label is returned."""
+        vals = np.array([0, 1, 1, 1, 2, 2, 3])
+        assert _max_overlap(vals) == 0
+
+    def test_all_nonpositive_returns_minus_one(self) -> None:
+        """Verify all non-positive values return -1."""
+        vals = np.array([0, -1, -2])
+        assert _max_overlap(vals) == -1
+
+    def test_single_positive(self) -> None:
+        """Verify single positive value is returned."""
+        vals = np.array([0, 0, 5])
+        assert _max_overlap(vals) == 4
+
+
+class TestGetParcelCentroids:
+    """Tests for _get_parcel_centroids()."""
+
+    def test_average_method(self, simple_sphere: Path, simple_parc: Path) -> None:
+        """Verify average centroid method returns correct shape."""
+        verts, faces = nib.load(simple_sphere).agg_data()
+        labels = nib.load(simple_parc).agg_data()
+        centroids = _get_parcel_centroids(verts, faces, labels, method="average")
+        assert centroids.shape == (2, 3)
+
+    def test_surface_method(self, simple_sphere: Path, simple_parc: Path) -> None:
+        """Verify surface centroid method returns vertex coordinates."""
+        verts, faces = nib.load(simple_sphere).agg_data()
+        labels = nib.load(simple_parc).agg_data()
+        centroids = _get_parcel_centroids(verts, faces, labels, method="surface")
+        assert centroids.shape == (2, 3)
+        for centroid in centroids:
+            assert any(np.allclose(centroid, v) for v in verts)
+
+    def test_geodesic_method(self, simple_sphere: Path, simple_parc: Path) -> None:
+        """Verify geodesic centroid method returns correct shape."""
+        verts, faces = nib.load(simple_sphere).agg_data()
+        labels = nib.load(simple_parc).agg_data()
+        centroids = _get_parcel_centroids(verts, faces, labels, method="geodesic")
+        assert centroids.shape == (2, 3)
+
+    def test_drop_labels(self, simple_sphere: Path) -> None:
+        """Verify specified labels are dropped from parcellation."""
+        verts, faces = nib.load(simple_sphere).agg_data()
+        labels = np.array([1, 1, 99, 2], dtype=np.int32)
+        labeltable = {1: "A", 2: "B", 99: "unknown"}
+        centroids = _get_parcel_centroids(
+            verts,
+            faces,
+            labels,
+            method="surface",
+            drop=["unknown"],
+            labeltable=labeltable,
+        )
+        assert centroids.shape == (2, 3)
+
+    def test_unknown_method_raises(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify unknown centroid method raises ValueError."""
+        verts, faces = nib.load(simple_sphere).agg_data()
+        labels = nib.load(simple_parc).agg_data()
+        with pytest.raises(ValueError, match="Expected one of"):
+            _get_parcel_centroids(verts, faces, labels, method="unknown")  # type: ignore
+
+
+class TestGetParcelCentroidsPublic:
+    """Tests for get_parcel_centroids() public interface."""
+
+    def test_without_parcellation(self, simple_sphere: Path) -> None:
+        """Verify vertex-level centroids when no parcellation is provided."""
+        centroids = get_parcel_centroids(simple_sphere)
+        verts, _ = nib.load(simple_sphere).agg_data()
+        assert centroids.shape == (len(verts), 3)
+
+    def test_with_parcellation(self, simple_sphere: Path, simple_parc: Path) -> None:
+        """Verify parcel-level centroids when parcellation is provided."""
+        centroids = get_parcel_centroids(simple_sphere, parcellation=simple_parc)
+        assert centroids.shape == (2, 3)
+
+
+class TestLoadSpins:
+    """Tests for load_spins()."""
+
+    def test_from_array(self) -> None:
+        """Verify array input is returned as-is."""
+        spins = np.array([[0, 1], [1, 0]], dtype=np.int32)
+        result = load_spins(spins)
+        np.testing.assert_array_equal(result, spins)
+
+    def test_from_npy_file(self, tmp_path: Path) -> None:
+        """Verify .npy file loading works."""
+        spins = np.array([[0, 1, 2], [1, 2, 0], [2, 0, 1]], dtype=np.int32)
+        np.save(tmp_path / "spins.npy", spins)
+        result = load_spins(tmp_path / "spins.npy")
+        np.testing.assert_array_equal(result, spins)
+
+    def test_from_csv_file(self, tmp_path: Path) -> None:
+        """Verify .csv file loading works."""
+        spins = np.array([[0, 1], [1, 0]], dtype=np.int32)
+        csv_path = tmp_path / "spins.csv"
+        np.savetxt(csv_path, spins, delimiter=",", fmt="%d")
+        result = load_spins(csv_path)
+        np.testing.assert_array_equal(result, spins)
+
+    def test_truncate_with_n_perm(self, rng: Generator) -> None:
+        """Verify n_perm truncates to requested number of permutations."""
+        spins = rng.integers(0, 10, size=(10, 20))
+        result = load_spins(spins, n_perm=5)
+        assert result.shape == (10, 5)
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        """Verify missing file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_spins(tmp_path / "nonexistent.npy")
+
+
+class TestSpinParcels:
+    """Tests for spin_parcels()."""
+
+    def test_output_shape(self, simple_sphere: Path, simple_parc: Path) -> None:
+        """Verify output shape is (n_parcels, n_rotate)."""
+        result = spin_parcels(simple_sphere, simple_parc, n_rotate=5, seed=42)
+        assert isinstance(result, SpinResult)
+        assert result.spin.shape == (2, 5)
+
+    def test_dual_hemisphere(
+        self, two_hemi_surfaces: tuple[Path, Path], two_hemi_parcs: tuple[Path, Path]
+    ) -> None:
+        """Verify dual-hemisphere parcellation works."""
+        result = spin_parcels(two_hemi_surfaces, two_hemi_parcs, n_rotate=5, seed=42)
+        assert result.spin.shape == (4, 5)
+
+    def test_with_precomputed_spins(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify precomputed spins are used instead of generating new ones."""
+        spins = np.array([[0, 1, 2, 3], [3, 2, 1, 0]], dtype=np.int32).T
+        result = spin_parcels(
+            simple_sphere, simple_parc, spins=spins, n_rotate=5, seed=42
+        )
+        assert result.spin.shape == (2, 2)
+
+    def test_mismatched_vertex_count_raises(
+        self, simple_sphere: Path, tmp_path: Path
+    ) -> None:
+        """Verify mismatched vertex count raises ValueError."""
+        bad_parc = tmp_path / "bad_parc.label.gii"
+        _make_gifti_parc(np.array([1, 2, 3], dtype=np.int32), [], bad_parc)
+        with pytest.raises(ValueError, match="does not match"):
+            spin_parcels(simple_sphere, bad_parc, n_rotate=3, seed=42)
+
+
+class TestSpinData:
+    """Tests for spin_data()."""
+
+    def test_output_shape(self, simple_sphere: Path, simple_parc: Path) -> None:
+        """Verify output shape is (n_parcels, n_rotate)."""
+        data = np.array([10.0, 20.0])
+        result = spin_data(data, simple_sphere, simple_parc, n_rotate=5, seed=42)
+        assert isinstance(result, SpinResult)
+        assert result.spin.shape == (2, 5)
+
+    def test_dual_hemisphere(
+        self, two_hemi_surfaces: tuple[Path, Path], two_hemi_parcs: tuple[Path, Path]
+    ) -> None:
+        """Verify dual-hemisphere data splicing works."""
+        data = np.array([10.0, 20.0, 30.0, 40.0])
+        result = spin_data(data, two_hemi_surfaces, two_hemi_parcs, n_rotate=5, seed=42)
+        assert result.spin.shape == (4, 5)
+
+    def test_with_precomputed_spins(
+        self, simple_sphere: Path, simple_parc: Path
+    ) -> None:
+        """Verify precomputed spins are used instead of generating new ones."""
+        data = np.array([10.0, 20.0])
+        spins = np.array([[0, 1, 2, 3], [3, 2, 1, 0]], dtype=np.int32).T
+        result = spin_data(
+            data, simple_sphere, simple_parc, spins=spins, n_rotate=2, seed=42
+        )
+        assert result.spin.shape == (2, 2)
+
+    def test_mismatched_vertex_count_raises(
+        self, simple_sphere: Path, tmp_path: Path
+    ) -> None:
+        """Verify mismatched vertex count raises ValueError."""
+        bad_parc = tmp_path / "bad_parc.label.gii"
+        _make_gifti_parc(np.array([1, 2, 3], dtype=np.int32), [], bad_parc)
+        data = np.array([10.0, 20.0])
+        with pytest.raises(ValueError, match="does not match"):
+            spin_data(data, simple_sphere, bad_parc, n_rotate=3, seed=42)
+
+
+class TestParcelsToVertices:
+    """Tests for parcels_to_vertices()."""
+
+    def test_basic_projection(self, simple_parc: Path) -> None:
+        """Verify basic parcel-to-vertex projection."""
+        data = np.array([10.0, 20.0])
+        result = parcels_to_vertices(data, simple_parc)
+        assert result.shape == (4,)
+        labels = nib.load(simple_parc).agg_data()
+        for i, lab in enumerate(labels):
+            if lab == 1:
+                assert np.isclose(result[i], 10.0)
+            elif lab == 2:
+                assert np.isclose(result[i], 20.0)
+
+    def test_2d_data(self, simple_parc: Path) -> None:
+        """Verify 2D data is projected correctly."""
+        data = np.array([[10.0, 100.0], [20.0, 200.0]])
+        result = parcels_to_vertices(data, simple_parc)
+        assert result.shape == (4, 2)
+
+    def test_background_gets_nan(self, tmp_path: Path) -> None:
+        """Verify background vertices get NaN."""
+        parc = tmp_path / "bg_parc.label.gii"
+        _make_gifti_parc(np.array([0, 1, 1, 2], dtype=np.int32), [], parc)
+        data = np.array([10.0, 20.0])
+        result = parcels_to_vertices(data, parc)
+        assert np.isnan(result[0])
+
+
+class TestVerticesToParcels:
+    """Tests for vertices_to_parcels()."""
+
+    def test_basic_reduction(self, simple_parc: Path) -> None:
+        """Verify basic vertex-to-parcel averaging."""
+        data = np.array([1.0, 2.0, 3.0, 4.0])
+        result = vertices_to_parcels(data, simple_parc)
+        assert result.shape == (2,)
+        np.testing.assert_allclose(result, [1.5, 3.5])
+
+    def test_2d_data(self, simple_parc: Path, rng: Generator) -> None:
+        """Verify 2D data is averaged correctly."""
+        data = rng.random((4, 3))
+        result = vertices_to_parcels(data, simple_parc)
+        assert result.shape == (2, 3)
+
+    def test_background_handling(self, tmp_path: Path) -> None:
+        """Verify background vertices are excluded from averaging."""
+        parc = tmp_path / "bg_parc.label.gii"
+        _make_gifti_parc(np.array([0, 1, 1, 2], dtype=np.int32), [], parc)
+        data = np.array([999.0, 1.0, 2.0, 3.0])
+        result = vertices_to_parcels(data, parc)
+        assert result.shape == (2,)
+        np.testing.assert_allclose(result, [1.5, 3.0])
+
+    def test_background_value_exclusion(self, simple_parc: Path) -> None:
+        """Verify custom background value is excluded."""
+        data = np.array([999.0, 1.0, 2.0, 3.0])
+        result = vertices_to_parcels(data, simple_parc, background=999.0)
+        np.testing.assert_allclose(result, [1.0, 2.5])
+
+    def test_mismatched_vertex_count_raises(self, simple_parc: Path) -> None:
+        """Verify mismatched vertex count raises ValueError."""
+        data = np.array([1.0, 2.0])
+        with pytest.raises(ValueError, match="does not match"):
+            vertices_to_parcels(data, simple_parc)

--- a/tests/unit/analysis/test_points.py
+++ b/tests/unit/analysis/test_points.py
@@ -220,14 +220,14 @@ class TestLoadGifti:
 
     def test_returns_gifti(self, surf_gifti_path: Path) -> None:
         """Verify loading a valid GIFTI file returns a GiftiImage."""
-        assert isinstance(points._load_gifti(surf_gifti_path), nib.GiftiImage)
+        assert isinstance(points.load_gifti(surf_gifti_path), nib.GiftiImage)
 
     def test_wrong_type_raises(self, tmp_path: Path) -> None:
         """Verify loading a non-GIFTI file raises ValueError."""
         nii_path = tmp_path / "dummy.nii.gz"
         nib.Nifti1Image(np.zeros((2, 2, 2)), np.eye(4)).to_filename(str(nii_path))
         with pytest.raises(ValueError, match="Gifti"):
-            points._load_gifti(nii_path)
+            points.load_gifti(nii_path)
 
 
 class TestRelabelGifti:
@@ -235,7 +235,7 @@ class TestRelabelGifti:
 
     def test_consecutive(self, parc_gifti_path: Path) -> None:
         """Verify output labels are remapped to consecutive indices."""
-        unique = np.unique(points._relabel_gifti(parc_gifti_path).agg_data())
+        unique = np.unique(points.relabel_gifti(parc_gifti_path).agg_data())
         np.testing.assert_array_equal(unique, [0, 1])
 
     def test_background_zeroed(self, tmp_path_factory: pytest.TempPathFactory) -> None:
@@ -246,7 +246,7 @@ class TestRelabelGifti:
             labels=[(1, "Cortex"), (2, "unknown"), (3, "Stem")],
             path=p,
         )
-        data = points._relabel_gifti(p).agg_data()
+        data = points.relabel_gifti(p).agg_data()
         assert data[1] == 0
         np.testing.assert_array_equal(np.unique(data[data > 0]), [1, 2])
 

--- a/tests/unit/analysis/test_points.py
+++ b/tests/unit/analysis/test_points.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import nibabel as nib
 import numpy as np
 import pytest
+from tests.unit.analysis.helpers import _make_gifti_parc, _make_gifti_surface
 
 from neuromaps_prime.analysis.surfaces import points
 
@@ -29,32 +30,6 @@ square_vertices = np.array(
     dtype=np.float32,
 )
 square_faces = np.array([[0, 1, 2], [1, 3, 2]], dtype=np.int32)
-
-
-def _make_gifti_surface(coords: np.ndarray, faces: np.ndarray, path: Path) -> None:
-    """Write a GIFTI surface file."""
-    ptarr = nib.gifti.GiftiDataArray(
-        coords.astype(np.float32), intent="NIFTI_INTENT_POINTSET"
-    )
-    tris = nib.gifti.GiftiDataArray(faces, intent="NIFTI_INTENT_TRIANGLE")
-    nib.GiftiImage(darrays=[ptarr, tris]).to_filename(path)
-
-
-def _make_gifti_parc(
-    data: np.ndarray,
-    labels: list[tuple[int, str]],
-    path: Path,
-) -> None:
-    """Write a GIFTI parcellation file."""
-    darr = nib.gifti.GiftiDataArray(
-        data.astype(np.int32), intent="NIFTI_INTENT_LABEL", datatype="NIFTI_TYPE_INT32"
-    )
-    lt = nib.gifti.GiftiLabelTable()
-    for key, name in labels:
-        lbl = nib.gifti.GiftiLabel(key=key)
-        lbl.label = name
-        lt.labels.append(lbl)
-    nib.GiftiImage(darrays=[darr], labeltable=lt).to_filename(path)
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/analysis/test_stats.py
+++ b/tests/unit/analysis/test_stats.py
@@ -16,12 +16,6 @@ if TYPE_CHECKING:
 
 # Fixtures
 @pytest.fixture(scope="module")
-def rng() -> Generator:
-    """Deterministic random number generator."""
-    return np.random.default_rng(12345)
-
-
-@pytest.fixture(scope="module")
 def random_vectors(rng: Generator) -> np.ndarray:
     """Random vectors for correlation testing."""
     return rng.normal(size=(2, 100))
@@ -188,15 +182,13 @@ class TestComputeMetric:
 class TestPermutationIndices:
     """Tests for _permutation_indices()."""
 
-    def test_shape(self) -> None:
+    def test_shape(self, rng: Generator) -> None:
         """Verify permutation index array has expected shape."""
-        rng = np.random.default_rng(0)
         idx = stats._permutation_indices(rng, n_perm=20, n_obs=7)
         assert idx.shape == (20, 7)
 
-    def test_every_row_is_permutation(self) -> None:
+    def test_every_row_is_permutation(self, rng: Generator) -> None:
         """Verify each row contains valid permutation of indices."""
-        rng = np.random.default_rng(0)
         idx = stats._permutation_indices(rng, n_perm=20, n_obs=7)
         expected = np.arange(7)
         for row in idx:


### PR DESCRIPTION
## This PR:
Add spatial null model modules for permutation-based statistical inference on cortical surfaces. Also refactors shared GIFTI utilities (`load_gifti`, `relabel_gifti`, `PARC_IGNORE`) from `points.py` into a new `images.py` module, and fixes a silent broadcasting bug in `_get_shared_triangles()`.

### Key changes:
- New `nulls` module, consisting of spin permutation core, spatial autoregressive surrogates (Burt 2018), and convenience wrappers for nulls. 
- New `images.py` with shared GIFTI loading/relabeling utilities extracted from `points.py`
- Bug fix for `_get_shared_triangles()`, which now broadcasts `shared_edges` correctly into the 3-D triplet array

## Type of Change
- [x] Bug fix
- [x] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)
- closes #194 by @kaitj