### PR TITLE
test: update and unmark xfail

### DIFF
--- a/tests/unit/graph/test_graph.py
+++ b/tests/unit/graph/test_graph.py
@@ -146,11 +146,10 @@ class TestNeuromapsGraph:
         )
         assert isinstance(atlas, models.SurfaceAtlas)
 
-    @pytest.mark.xfail(reason="Not in graph YAML yet")
     def test_fetch_surface_annotation(self, graph: NeuromapsGraph) -> None:
         """Test fetching surface atlas."""
         atlas = graph.fetch_surface_annotation(
-            space="Yerkes19", density="32k", label="myelin", hemisphere="left"
+            space="Yerkes19", density="10k", label="PC_MarkovMonkey", hemisphere="left"
         )
         assert isinstance(atlas, models.SurfaceAnnotation)
 
@@ -189,11 +188,10 @@ class TestNeuromapsGraph:
         )
         assert isinstance(atlas, models.VolumeAtlas)
 
-    @pytest.mark.xfail(reason="Not in graph YAML yet")
     def test_fetch_volume_annotation(self, graph: NeuromapsGraph) -> None:
         """Test fetching surface atlas."""
         atlas = graph.fetch_volume_annotation(
-            space="Yerkes19", resolution="250um", label="myelin"
+            space="NMT2Sym", resolution="250um", label="PC_CHARM_scale_1"
         )
         assert isinstance(atlas, models.VolumeAnnotation)
 


### PR DESCRIPTION
## This PR:
The two annotation fetcher unit tests were marked with `xfail` as annotations weren't yet added to the graph YAML. Since these are mocked in the unit testing and have been added to the graph YAML, the two tests were updated to mock fetch from annotations and unmarked as xfail.

## Type of Change
- [ ] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [x] Other

## Related Issue(s)
- closes #216 by @kaitj 