### PR TITLE
fix: replace '>' with '|' in build step

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,12 +33,12 @@ jobs:
     - name: Install the project
       run: uv sync --only-group docs
     - name: Build docs
-      run: >
+      run: |
         uv run pdoc src/neuromaps_prime \
-        -o docs_build \
-        -t docs/pdoc-theme \
-        --docformat google \
-        --favicon https://raw.githubusercontent.com/childmindresearch/neuromaps-prime/refs/heads/main/.github/neuromaps_prime.svg
+          -o docs_build \
+          -t docs/pdoc-theme \
+          --docformat google \
+          --favicon https://raw.githubusercontent.com/childmindresearch/neuromaps-prime/refs/heads/main/.github/neuromaps_prime.svg
     - name: Setup Pages
       uses: actions/configure-pages@v6
     - name: Upload artifact


### PR DESCRIPTION
## This PR:
The CI to build the static documentation page was timing out.

## Type of Change
- [x] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [ ] Other

## Related Issue(s)
- n/a