### PR TITLE
refactor: fail for github blob url

### DIFF
--- a/scripts/validate_urls.py
+++ b/scripts/validate_urls.py
@@ -30,6 +30,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import aiohttp
 import yaml
@@ -260,17 +261,39 @@ async def _get_range(
     )
 
 
+def _is_github_blob_url(url: str) -> bool:
+    """Return True if *url* is a GitHub ``/blob/`` file-page URL.
+
+    These are human-facing pages (e.g. ``github.com/owner/repo/blob/main/file``)
+    that render an HTML view rather than exposing the raw file, so they cannot
+    be consumed programmatically. Query strings and fragments are ignored.
+
+    Args:
+        url: A candidate URL string.
+
+    Returns:
+        True if the URL points at a ``github.com`` blob page, else False.
+    """
+    parts = urlsplit(url)
+    host = (parts.hostname or "").lower().removeprefix("www.")
+    if host != "github.com":
+        return False
+    segments = [s for s in parts.path.split("/") if s]
+    return len(segments) >= 3 and segments[2] == "blob"
+
+
 async def check_url(
     session: aiohttp.ClientSession,
     url: str,
     sources: list[Path],
 ) -> CheckResult:
-    """Probe *url* asynchronously without downloading its body.
+    """Validate *url* without downloading its body.
 
     Strategy:
-        1. Send a HEAD request, retrying on HTTP 429 with backoff.
-        2. On 403/405 (server rejects HEAD), fall back to :func:`_get_range`.
-        3. Map any other HTTP/network error to a failed :class:`CheckResult`.
+        1. Reject unsupported URL types (GitHub ``/blob/`` pages) up front.
+        2. Send a HEAD request, retrying on HTTP 429 with backoff.
+        3. On 403/405 (server rejects HEAD), fall back to :func:`_get_range`.
+        4. Map any other HTTP/network error to a failed :class:`CheckResult`.
 
     Args:
         session: Shared :class:`aiohttp.ClientSession`.
@@ -280,6 +303,14 @@ async def check_url(
     Returns:
         :class:`CheckResult` describing whether the URL is reachable.
     """
+    if _is_github_blob_url(url):
+        return CheckResult(
+            url,
+            ok=False,
+            detail="unsupported URL type: GitHub blob URL (use a raw file URL)",
+            sources=sources,
+        )
+
     result = await _probe(session, url=url, method="HEAD", sources=sources)
     if not result.ok and result.detail in _GET_RANGE_TRIGGER_DETAILS:
         return await _get_range(session, url, sources)

--- a/src/neuromaps_prime/remote/github.py
+++ b/src/neuromaps_prime/remote/github.py
@@ -17,9 +17,6 @@ class GitHubFileMeta(BaseModel):
     download_url: str
 
 
-_BLOB_RE = re.compile(
-    r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/blob/(?P<ref>[^/]+)/(?P<path>.+)"
-)
 _RAW_RE = re.compile(
     r"raw\.githubusercontent\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/"
     r"(?:refs/(?:tags|heads)/)?(?P<ref>[^/]+)/(?P<path>.+)"
@@ -36,9 +33,9 @@ class GitHubStorage(BaseModel):
 
     @staticmethod
     def _parse(url: str) -> tuple[str, str, str, str]:
-        m = _BLOB_RE.search(url) or _RAW_RE.search(url)
+        m = _RAW_RE.search(url)
         if not m:
-            raise ValueError(f"Unrecognized GitHub URL: {url}")
+            raise ValueError(f"Unrecognized / unsupported GitHub URL: {url}")
         return m["owner"], m["repo"], m["ref"], m["path"]
 
     def get_meta(self, url: str) -> GitHubFileMeta:

--- a/tests/unit/remote/test_github.py
+++ b/tests/unit/remote/test_github.py
@@ -22,7 +22,6 @@ MOCK_OWNER = "mockowner"
 MOCK_REPO = "mockrepo"
 MOCK_REF = "v0.1"
 MOCK_PATH = "data/test.txt"
-MOCK_URL = f"https://github.com/{MOCK_OWNER}/{MOCK_REPO}/blob/{MOCK_REF}/{MOCK_PATH}"
 MOCK_DOWNLOAD_URL = (
     f"https://raw.githubusercontent.com/{MOCK_OWNER}/{MOCK_REPO}/{MOCK_REF}/{MOCK_PATH}"
 )
@@ -66,14 +65,6 @@ class TestGitHubFileMeta:
 class TestGitHubStorage:
     """Test suite for GitHubStorage download and metadata retrieval."""
 
-    def test_parse_blob_url(self) -> None:
-        """Test blob URL is correctly parsed into owner/repo/ref/path."""
-        owner, repo, ref, path = GitHubStorage._parse(MOCK_URL)
-        assert owner == MOCK_OWNER
-        assert repo == MOCK_REPO
-        assert ref == MOCK_REF
-        assert path == MOCK_PATH
-
     def test_parse_raw_url(self) -> None:
         """Test bare raw URL is correctly parsed into owner/repo/ref/path."""
         owner, repo, ref, path = GitHubStorage._parse(MOCK_RAW_URL)
@@ -98,16 +89,23 @@ class TestGitHubStorage:
         assert ref == MOCK_REF
         assert path == MOCK_PATH
 
+    def test_parse_blob_url_raises(self) -> None:
+        """Test blob URL is raises ValueError."""
+        with pytest.raises(ValueError, match="unsupported"):
+            GitHubStorage._parse(
+                f"https://github.com/{MOCK_OWNER}/{MOCK_REPO}/blob/{MOCK_REF}/{MOCK_PATH}"
+            )
+
     def test_parse_invalid_url_raises(self) -> None:
         """Test parsing a non-GitHub URL raises ValueError."""
-        with pytest.raises(ValueError, match="Unrecognized GitHub URL"):
+        with pytest.raises(ValueError, match="Unrecognized"):
             GitHubStorage._parse(f"https://github.com/{MOCK_OWNER}/{MOCK_REPO}")
 
     @patch("neuromaps_prime.remote.github.requests.get")
     def test_get_meta(self, mock_get: MagicMock, mock_meta_response: MagicMock) -> None:
         """Test get_meta returns parsed GitHubFileMeta and calls correct URL."""
         mock_get.return_value = mock_meta_response
-        meta = GitHubStorage().get_meta(MOCK_URL)
+        meta = GitHubStorage().get_meta(MOCK_RAW_URL)
         assert meta.name == "test.txt"
         assert meta.sha == MOCK_SHA
         mock_get.assert_called_once_with(
@@ -121,7 +119,7 @@ class TestGitHubStorage:
         """Test get_meta propagates HTTP errors from the remote server."""
         mock_get.return_value.raise_for_status.side_effect = Exception("HTTP Error")
         with pytest.raises(Exception, match="HTTP Error"):
-            GitHubStorage().get_meta(MOCK_URL)
+            GitHubStorage().get_meta(MOCK_RAW_URL)
 
     @patch("neuromaps_prime.remote.github.requests.get")
     def test_download_valid(
@@ -131,7 +129,7 @@ class TestGitHubStorage:
         mock_download = MagicMock(iter_content=MagicMock(return_value=[MOCK_CONTENT]))
         mock_get.side_effect = [mock_meta_response, mock_download]
         dest = tmp_path / "test.txt"
-        GitHubStorage().download(MOCK_URL, dest)
+        GitHubStorage().download(MOCK_RAW_URL, dest)
         assert dest.read_bytes() == MOCK_CONTENT
 
     @patch("neuromaps_prime.remote.github.requests.get")
@@ -144,7 +142,7 @@ class TestGitHubStorage:
         )
         mock_get.side_effect = [mock_meta_response, mock_download]
         with pytest.raises(ValueError, match="Checksum mismatch"):
-            GitHubStorage().download(MOCK_URL, tmp_path / "test.txt")
+            GitHubStorage().download(MOCK_RAW_URL, tmp_path / "test.txt")
 
     def test_default_chunk_size(self) -> None:
         """Test chunk_size defaults to 8192."""


### PR DESCRIPTION
## This PR:
- Update package to raise error when encountering github blob urls (`neuromaps_prime.remote.github`)
- Update validation script to cause CI to fail if blob url is encountered (`scripts/validate_urls.py`)

## Type of Change
- [ ] Bug fix
- [ ] Enhancement
- [ ] Resource contribution
- [ ] Documentation
- [x] Other

## Related Issue(s)
- closes #241 by @tamsinrogers